### PR TITLE
Add further measurement properties

### DIFF
--- a/docs/package.rst
+++ b/docs/package.rst
@@ -149,7 +149,6 @@ highdicom.sr.utils module
 
 .. automodule:: highdicom.sr.utils
    :members:
-   :inherited-members:
    :special-members: __call__
    :undoc-members:
    :show-inheritance:

--- a/docs/package.rst
+++ b/docs/package.rst
@@ -149,6 +149,7 @@ highdicom.sr.utils module
 
 .. automodule:: highdicom.sr.utils
    :members:
+   :inherited-members:
    :special-members: __call__
    :undoc-members:
    :show-inheritance:

--- a/src/highdicom/sr/content.py
+++ b/src/highdicom/sr/content.py
@@ -1172,6 +1172,8 @@ class FindingSite(CodeContentItem):
 
     @property
     def topographical_modifier(self) -> Union[CodedConcept, None]:
+        if not hasattr(self, 'ContentSequence'):
+            return None
         matches = find_content_items(
             self,
             name=codes.SCT.TopographicalModifier,
@@ -1188,6 +1190,8 @@ class FindingSite(CodeContentItem):
 
     @property
     def laterality(self) -> Union[CodedConcept, None]:
+        if not hasattr(self, 'ContentSequence'):
+            return None
         matches = find_content_items(
             self,
             name=codes.SCT.Laterality,

--- a/src/highdicom/sr/content.py
+++ b/src/highdicom/sr/content.py
@@ -270,7 +270,7 @@ class SourceImageForMeasurement(ImageContentItem):
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
-            Dataset representing an SR Content Item with value type SCOORD
+            Dataset representing an SR Content Item with value type IMAGE
 
         Returns
         -------

--- a/src/highdicom/sr/templates.py
+++ b/src/highdicom/sr/templates.py
@@ -2365,6 +2365,8 @@ class Measurement(Template):
     @property
     def derivation(self) -> Union[CodedConcept, None]:
         """Union[highdicom.sr.CodedConcept, None]: derivation"""
+        if not hasattr(self[0], 'ContentSequence'):
+            return None
         matches = find_content_items(
             self[0],
             name=codes.DCM.Derivation,
@@ -2377,6 +2379,8 @@ class Measurement(Template):
     @property
     def method(self) -> Union[CodedConcept, None]:
         """Union[highdicom.sr.CodedConcept, None]: method"""
+        if not hasattr(self[0], 'ContentSequence'):
+            return None
         matches = find_content_items(
             self[0],
             name=codes.SCT.MeasurementMethod,
@@ -2389,6 +2393,8 @@ class Measurement(Template):
     @property
     def referenced_images(self) -> List[SourceImageForMeasurement]:
         """List[highdicom.sr.SourceImageForMeasurement]: referenced images"""
+        if not hasattr(self[0], 'ContentSequence'):
+            return []
         matches = find_content_items(
             self[0],
             name=codes.DCM.SourceOfMeasurement,
@@ -2399,6 +2405,8 @@ class Measurement(Template):
     @property
     def finding_sites(self) -> List[FindingSite]:
         """List[highdicom.sr.FindingSite]: finding sites"""
+        if not hasattr(self[0], 'ContentSequence'):
+            return []
         matches = find_content_items(
             self[0],
             name=codes.SCT.FindingSite,

--- a/src/highdicom/sr/templates.py
+++ b/src/highdicom/sr/templates.py
@@ -2354,13 +2354,59 @@ class Measurement(Template):
 
     @property
     def unit(self) -> CodedConcept:
-        """highdicom.sr.coding.CodedConcept: unit"""
+        """highdicom.sr.CodedConcept: unit"""
         return self[0].unit
 
     @property
     def qualifier(self) -> Union[CodedConcept, None]:
-        """Union[highdicom.sr.coding.CodedConcept, None]: qualifier"""
+        """Union[highdicom.sr.CodedConcept, None]: qualifier"""
         return self[0].qualifier
+
+    @property
+    def derivation(self) -> Union[CodedConcept, None]:
+        """Union[highdicom.sr.CodedConcept, None]: derivation"""
+        matches = find_content_items(
+            self[0],
+            name=codes.DCM.Derivation,
+            value_type=ValueTypeValues.CODE
+        )
+        if len(matches) > 0:
+            return matches[0].value
+        return None
+
+    @property
+    def method(self) -> Union[CodedConcept, None]:
+        """Union[highdicom.sr.CodedConcept, None]: method"""
+        matches = find_content_items(
+            self[0],
+            name=codes.SCT.MeasurementMethod,
+            value_type=ValueTypeValues.CODE
+        )
+        if len(matches) > 0:
+            return matches[0].value
+        return None
+
+    @property
+    def referenced_images(self) -> List[SourceImageForMeasurement]:
+        """List[highdicom.sr.SourceImageForMeasurement]: referenced images"""
+        matches = find_content_items(
+            self[0],
+            name=codes.DCM.SourceOfMeasurement,
+            value_type=ValueTypeValues.IMAGE
+        )
+        return [SourceImageForMeasurement.from_dataset(m) for m in matches]
+
+    @property
+    def finding_sites(self) -> List[FindingSite]:
+        """List[highdicom.sr.FindingSite]: finding sites"""
+        matches = find_content_items(
+            self[0],
+            name=codes.SCT.FindingSite,
+            value_type=ValueTypeValues.CODE
+        )
+        if len(matches) > 0:
+            return [FindingSite.from_dataset(m) for m in matches]
+        return []
 
 
 class MeasurementsAndQualitativeEvaluations(Template):

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -2361,6 +2361,12 @@ class TestMeasurement(unittest.TestCase):
             graphic_data=np.array([[1.0, 1.0]]),
             source_image=self._image
         )
+        self._ref_images = [
+            SourceImageForMeasurement(
+                referenced_sop_class_uid='1.2.840.10008.5.1.4.1.1.2.2',
+                referenced_sop_instance_uid=generate_uid()
+            ) for _ in range(3)
+        ]
 
     def test_construction_with_required_parameters(self):
         measurement = Measurement(
@@ -2412,7 +2418,8 @@ class TestMeasurement(unittest.TestCase):
             tracking_identifier=self._tracking_identifier,
             method=self._method,
             derivation=self._derivation,
-            finding_sites=[self._finding_site, ]
+            finding_sites=[self._finding_site, ],
+            referenced_images=self._ref_images
         )
 
         subitem = measurement[0].ContentSequence[0]
@@ -2436,6 +2443,18 @@ class TestMeasurement(unittest.TestCase):
         assert subitem.ConceptCodeSequence[0] == self._location
         # Laterality and topological modifier were not specified
         assert not hasattr(subitem, 'ContentSequence')
+
+        sites = measurement.finding_sites
+        assert len(sites) == 1
+        assert sites[0] == self._finding_site
+
+        assert measurement.derivation == self._derivation
+        assert measurement.method == self._method
+        ref_images = measurement.referenced_images
+        assert len(ref_images) == len(self._ref_images)
+        for retrieved, original in zip(ref_images, self._ref_images):
+            assert isinstance(retrieved, SourceImageForMeasurement)
+            assert retrieved == original
 
 
 class TestQualitativeEvaluation(unittest.TestCase):


### PR DESCRIPTION
I have implemented further properties on the `Measurement` class because I had need for them. Specifically, `referenced_images`, `method`, `derivation` and `finding_sites`. This is not intended to be complete, there are still a few left unimplemented, but these are more complex as they combine multiple content items.