### PR TITLE
Change person name checks from errors to warnings

### DIFF
--- a/src/highdicom/valuerep.py
+++ b/src/highdicom/valuerep.py
@@ -7,7 +7,7 @@ from pydicom.valuerep import PersonName
 
 
 def check_person_name(person_name: Union[str, PersonName]) -> None:
-    """Check the value representation person name strings.
+    """Check value is valid for the value representation "person name".
 
     The DICOM Person Name (PN) value representation has a specific format with
     multiple components (family name, given name, middle name, prefix, suffix)
@@ -65,7 +65,7 @@ def check_person_name(person_name: Union[str, PersonName]) -> None:
 
 
 def _check_code_string(value: str) -> None:
-    """Check the value representation person name strings.
+    """Check value is valid for the value representation "code string".
 
     Parameters
     ----------

--- a/src/highdicom/valuerep.py
+++ b/src/highdicom/valuerep.py
@@ -1,6 +1,7 @@
 """Functions for working with DICOM value representations."""
 import re
 from typing import Union
+import warnings
 
 from pydicom.valuerep import PersonName
 
@@ -50,7 +51,7 @@ def check_person_name(person_name: Union[str, PersonName]) -> None:
         'sect_6.2.html#sect_6.2.1.2'
     )
     if '^' not in person_name and person_name != '':  # empty string is allowed
-        raise ValueError(
+        warnings.warn(
             f'The string "{person_name}" is unlikely to represent the '
             'intended person name since it contains only a single component. '
             'Construct a person name according to the format in described '
@@ -58,7 +59,8 @@ def check_person_name(person_name: Union[str, PersonName]) -> None:
             'pydicom.valuerep.PersonName.from_named_components() method '
             'to construct the person name correctly. If a single-component '
             'name is really intended, add a trailing caret character to '
-            'disambiguate the name.'
+            'disambiguate the name.',
+            UserWarning
         )
 
 

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -861,7 +861,7 @@ class TestContentItem(unittest.TestCase):
     def test_pname_content_item_invalid_name(self):
         name = codes.DCM.PersonObserverName
         value = 'John Doe'  # invalid name format
-        with pytest.raises(ValueError):
+        with pytest.warns(UserWarning):
             PnameContentItem(
                 name=name,
                 value=value,
@@ -1363,7 +1363,7 @@ class TestPersonObserverIdentifyingAttributes(unittest.TestCase):
         assert seq[4].ConceptCodeSequence[0] == self._role_in_procedure
 
     def test_construction_invalid(self):
-        with pytest.raises(ValueError):
+        with pytest.warns(UserWarning):
             PersonObserverIdentifyingAttributes(
                 name=self._invalid_name
             )

--- a/tests/test_valuerep.py
+++ b/tests/test_valuerep.py
@@ -54,13 +54,13 @@ def test_valid_person_name_objects(name):
 
 @pytest.mark.parametrize('name', invalid_test_names)
 def test_invalid_person_name_strings(name):
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         check_person_name(name)
 
 
 @pytest.mark.parametrize('name', invalid_test_names)
 def test_invalid_person_name_objects(name):
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         check_person_name(PersonName(name))
 
 


### PR DESCRIPTION
I think I was probably a bit over zealous in raising an error when a malformed Person Name is passed. We are finding here that many DICOM files exist "in the wild" with incorrectly formatted patient names, unfortunately. This is now bringing down model inference pipelines when attempting to copy across the name and crashing everything when writing out results...

I suggest a more pragmatic compromise may be to raise a warning instead of an error, as implemented in this PR. @hackermd thoughts?