### PR TITLE
Remove superfluous file meta information attributes

### DIFF
--- a/src/highdicom/base.py
+++ b/src/highdicom/base.py
@@ -129,8 +129,6 @@ class SOPClass(Dataset):
         # to a file in PS3.10 format.
         self.preamble = b'\x00' * 128
         self.file_meta = FileMetaDataset()
-        self.file_meta.DICOMPrefix = 'DICM'
-        self.file_meta.FilePreamble = self.preamble
         self.file_meta.TransferSyntaxUID = UID(transfer_syntax_uid)
         self.file_meta.MediaStorageSOPClassUID = UID(sop_class_uid)
         self.file_meta.MediaStorageSOPInstanceUID = UID(sop_instance_uid)

--- a/src/highdicom/base.py
+++ b/src/highdicom/base.py
@@ -127,7 +127,6 @@ class SOPClass(Dataset):
 
         # Include all File Meta Information required for writing SOP instance
         # to a file in PS3.10 format.
-        self.preamble = b'\x00' * 128
         self.file_meta = FileMetaDataset()
         self.file_meta.TransferSyntaxUID = UID(transfer_syntax_uid)
         self.file_meta.MediaStorageSOPClassUID = UID(sop_class_uid)

--- a/src/highdicom/base.py
+++ b/src/highdicom/base.py
@@ -127,6 +127,7 @@ class SOPClass(Dataset):
 
         # Include all File Meta Information required for writing SOP instance
         # to a file in PS3.10 format.
+        self.preamble = b'\x00' * 128
         self.file_meta = FileMetaDataset()
         self.file_meta.TransferSyntaxUID = UID(transfer_syntax_uid)
         self.file_meta.MediaStorageSOPClassUID = UID(sop_class_uid)

--- a/tests/test_ann.py
+++ b/tests/test_ann.py
@@ -508,5 +508,3 @@ class TestMicroscopyBulkSimpleAnnotations(unittest.TestCase):
         assert isinstance(retrieved_group, AnnotationGroup)
         assert retrieved_group.number == 1
         assert retrieved_group.label == first_label
-
-        annotations.save_as('/tmp/ann.dcm')


### PR DESCRIPTION
DICOMPrefix and FilePreamble are not recognized and not needed by pydicom and gives warnings/exceptions depending on setting.

Removed file save to /tmp-path.