### PR TITLE
Fixes for pydicom 2.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
     package_dir={'': 'src'},
     python_requires='>=3.6',
     install_requires=[
-        'pydicom>=2.2.2',
+        'pydicom>=2.3.0',
         'numpy>=1.19',
         'pillow>=8.3',
         'pillow-jpls>=1.0',

--- a/src/highdicom/ko/sop.py
+++ b/src/highdicom/ko/sop.py
@@ -9,7 +9,7 @@ from pydicom.uid import (
     ImplicitVRLittleEndian,
     UID,
 )
-from pydicom._storage_sopclass_uids import (
+from pydicom.uid import (
     KeyObjectSelectionDocumentStorage,
 )
 

--- a/src/highdicom/sc/sop.py
+++ b/src/highdicom/sc/sop.py
@@ -5,7 +5,7 @@ import datetime
 from typing import Any, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
-from pydicom._storage_sopclass_uids import SecondaryCaptureImageStorage
+from pydicom.uid import SecondaryCaptureImageStorage
 from pydicom.dataset import Dataset
 from pydicom.encaps import encapsulate
 from pydicom.sr.codedict import codes

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -718,7 +718,6 @@ class Segmentation(SOPClass):
 
                 pffp_item = Dataset()
                 frame_content_item = Dataset()
-                frame_content_item.DimensionIndexValues = [segment_number]
 
                 # Look up the position of the plane relative to the indexed
                 # dimension.
@@ -749,7 +748,9 @@ class Segmentation(SOPClass):
                         'three dimensional coordinate system based on '
                         'dimension index values: {}'.format(j, error)
                     )
-                frame_content_item.DimensionIndexValues.extend(index_values)
+                frame_content_item.DimensionIndexValues = (
+                    [segment_number] + index_values
+                )
                 pffp_item.FrameContentSequence = [frame_content_item]
                 if self._coordinate_system == CoordinateSystemNames.SLIDE:
                     pffp_item.PlanePositionSlideSequence = plane_positions[j]

--- a/src/highdicom/sr/content.py
+++ b/src/highdicom/sr/content.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from typing import cast, List, Optional, Sequence, Union
 
 import numpy as np
-from pydicom._storage_sopclass_uids import (
+from pydicom.uid import (
     SegmentationStorage,
     VLWholeSlideMicroscopyImageStorage
 )

--- a/src/highdicom/sr/sop.py
+++ b/src/highdicom/sr/sop.py
@@ -13,7 +13,7 @@ from pydicom.uid import (
     UID,
 )
 from pydicom.valuerep import DT, PersonName
-from pydicom._storage_sopclass_uids import (
+from pydicom.uid import (
     ComprehensiveSRStorage,
     Comprehensive3DSRStorage,
     EnhancedSRStorage,

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -14,7 +14,7 @@ from pydicom.sr.codedict import codes
 from pydicom.sr.coding import Code
 from pydicom.uid import generate_uid
 from pydicom.valuerep import DA, DS, DT, TM, PersonName
-from pydicom._storage_sopclass_uids import SegmentationStorage
+from pydicom.uid import SegmentationStorage
 
 from highdicom.sr import CodedConcept
 from highdicom.sr import (

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -1872,7 +1872,7 @@ class TestReferencedSegment(unittest.TestCase):
         )
         assert (
             ref_seg[0].ReferencedSOPSequence[0].ReferencedFrameNumber ==
-            [self._ref_frame_number]
+            self._ref_frame_number
         )
         assert (
             ref_seg[1].ReferencedSOPSequence[0].ReferencedSOPClassUID ==
@@ -1941,7 +1941,7 @@ class TestReferencedSegment(unittest.TestCase):
         )
         assert (
             ref_seg[0].ReferencedSOPSequence[0].ReferencedFrameNumber ==
-            [self._ref_frame_number]
+            self._ref_frame_number
         )
         assert (
             ref_seg[1].ReferencedSOPSequence[0].ReferencedSOPClassUID ==


### PR DESCRIPTION
Pydicom 2.3.0 was released yesterday and broke stuff (#162). This PR:
- Bumps pydicom to version 2.3.0 required
- Fixes a part of the Segmentation code that was broken by the change
- Fix a few other tests broken by the change
- Move to importing SOPClassUIDs from the pydicom public API, as these have now been publicly exposed (see #160 )

Closes #162 and #160