### PR TITLE
Change LUT word length

### DIFF
--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -906,7 +906,7 @@ class TestPaletteColorLUT(TestCase):
         assert lut.BluePaletteColorLookupTableDescriptor[2] == 8
         assert not hasattr(lut, 'RedPaletteColorLookupTableDescriptor')
         assert not hasattr(lut, 'GreenPaletteColorLookupTableDescriptor')
-        assert len(lut.BluePaletteColorLookupTableData) == lut_data.shape[0] * 2
+        assert len(lut.BluePaletteColorLookupTableData) == lut_data.shape[0]
         assert not hasattr(lut, 'RedPaletteColorLookupTableData')
         assert not hasattr(lut, 'GreenPaletteColorLookupTableData')
 

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -843,9 +843,9 @@ class TestAdvancedBlending(unittest.TestCase):
         assert ds.BluePaletteColorLookupTableDescriptor[0] == 256
         assert ds.BluePaletteColorLookupTableDescriptor[1] == 0
         assert ds.BluePaletteColorLookupTableDescriptor[2] == 8
-        assert len(ds.SegmentedRedPaletteColorLookupTableData) == 12
-        assert len(ds.SegmentedGreenPaletteColorLookupTableData) == 12
-        assert len(ds.SegmentedBluePaletteColorLookupTableData) == 12
+        assert len(ds.SegmentedRedPaletteColorLookupTableData) == 6
+        assert len(ds.SegmentedGreenPaletteColorLookupTableData) == 6
+        assert len(ds.SegmentedBluePaletteColorLookupTableData) == 6
         assert not hasattr(ds, 'ThresholdSequence')
         assert not hasattr(ds, 'RescaleSlope')
         assert not hasattr(ds, 'RescaleIntercept')


### PR DESCRIPTION
We can continue to discuss the right thing to do here, but here's the PR to switch to storing 1 byte per entry when bits allocated is 8, if we decide to use it. I vote for merging this