### PR TITLE
Remove 8 bit LUTs

### DIFF
--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -1537,7 +1537,7 @@ class LUT(Dataset):
             Pixel value that will be mapped to the first value in the
             lookup-table.
         lut_data: numpy.ndarray
-            Lookup table data. Must be of type uint8 or uint16.
+            Lookup table data. Must be of type uint16.
         lut_explanation: Union[str, None], optional
             Free-form text explanation of the meaning of the LUT.
 
@@ -1578,13 +1578,13 @@ class LUT(Dataset):
         elif len_data == 2**16:
             # Per the standard, this is recorded as 0
             len_data = 0
-        if lut_data.dtype.type == np.uint8:
-            bits_per_entry = 8
-        elif lut_data.dtype.type == np.uint16:
+        # Note 8 bit LUT data is unsupported pending clarification on the
+        # standard
+        if lut_data.dtype.type == np.uint16:
             bits_per_entry = 16
         else:
             raise ValueError(
-                "Numpy array must have dtype uint8 or uint16."
+                "Numpy array must have dtype uint16."
             )
         # The LUT data attribute has VR OW (16-bit other words)
         self.LUTData = lut_data.astype(np.uint16).tobytes()
@@ -1603,7 +1603,7 @@ class LUT(Dataset):
     def lut_data(self) -> np.ndarray:
         """numpy.ndarray: LUT data"""
         if self.bits_per_entry == 8:
-            dtype = np.uint8
+            raise RuntimeError("8 bit LUTs are currently unsupported.")
         elif self.bits_per_entry == 16:
             dtype = np.uint16
         else:
@@ -1670,7 +1670,7 @@ class ModalityLUT(LUT):
             Pixel value that will be mapped to the first value in the
             lookup-table.
         lut_data: numpy.ndarray
-            Lookup table data. Must be of type uint8 or uint16.
+            Lookup table data. Must be of type uint16.
         lut_explanation: Union[str, None], optional
             Free-form text explanation of the meaning of the LUT.
 
@@ -1705,7 +1705,7 @@ class VOILUT(LUT):
             Pixel value that will be mapped to the first value in the
             lookup-table.
         lut_data: numpy.ndarray
-            Lookup table data. Must be of type uint8 or uint16.
+            Lookup table data. Must be of type uint16.
         lut_explanation: Union[str, None], optional
             Free-form text explanation of the meaning of the LUT.
 
@@ -1964,7 +1964,7 @@ class PresentationLUT(LUT):
             Pixel value that will be mapped to the first value in the
             lookup-table.
         lut_data: numpy.ndarray
-            Lookup table data. Must be of type uint8 or uint16.
+            Lookup table data. Must be of type uint16.
         lut_explanation: Union[str, None], optional
             Free-form text explanation of the meaning of the LUT.
 
@@ -2047,7 +2047,7 @@ class PaletteColorLUT(Dataset):
             Pixel value that will be mapped to the first value in the
             lookup table.
         lut_data: numpy.ndarray
-            Lookup table data. Must be of type uint8 or uint16.
+            Lookup table data. Must be of type uint16.
         color: str
             Text representing the color (``red``, ``green``, or
             ``blue``).
@@ -2091,13 +2091,13 @@ class PaletteColorLUT(Dataset):
             number_of_entries = 0
         else:
             number_of_entries = len_data
-        if lut_data.dtype.type == np.uint8:
-            bits_per_entry = 8
-        elif lut_data.dtype.type == np.uint16:
+        # Note 8 bit LUT data is unsupported pending clarification on the
+        # standard
+        if lut_data.dtype.type == np.uint16:
             bits_per_entry = 16
         else:
             raise ValueError(
-                "Numpy array must have dtype uint8 or uint16."
+                "Numpy array must have dtype uint16."
             )
 
         if color.lower() not in ('red', 'green', 'blue'):
@@ -2123,7 +2123,7 @@ class PaletteColorLUT(Dataset):
     def lut_data(self) -> np.ndarray:
         """numpy.ndarray: lookup table data"""
         if self.bits_per_entry == 8:
-            dtype = np.uint8
+            raise RuntimeError("8 bit LUTs are currently unsupported.")
         elif self.bits_per_entry == 16:
             dtype = np.uint16
         else:
@@ -2184,7 +2184,7 @@ class SegmentedPaletteColorLUT(Dataset):
             Pixel value that will be mapped to the first value in the
             lookup table.
         segmented_lut_data: numpy.ndarray
-            Segmented lookup table data. Must be of type uint8 or uint16.
+            Segmented lookup table data. Must be of type uint16.
         color: str
             Free-form text explanation of the color (``red``, ``green``, or
             ``blue``).
@@ -2233,15 +2233,14 @@ class SegmentedPaletteColorLUT(Dataset):
         elif len_data == 2**16:
             # Per the standard, this is recorded as 0
             len_data = 0
-        if segmented_lut_data.dtype.type == np.uint8:
-            bits_per_entry = 8
-            self._dtype = np.uint8
-        elif segmented_lut_data.dtype.type == np.uint16:
+        # Note 8 bit LUT data is currently unsupported pending clarification on
+        # the standard
+        if segmented_lut_data.dtype.type == np.uint16:
             bits_per_entry = 16
             self._dtype = np.uint16
         else:
             raise ValueError(
-                "Numpy array must have dtype uint8 or uint16."
+                "Numpy array must have dtype uint16."
             )
 
         if color.lower() not in ('red', 'green', 'blue'):

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -119,17 +119,18 @@ class TestLUT(TestCase):
         self._lut_data_16 = np.arange(510, 600, dtype=np.uint16)
         self._explanation = 'My LUT'
 
-    def test_construction(self):
-        first_value = 0
-        lut = LUT(
-            first_mapped_value=first_value,
-            lut_data=self._lut_data,
-        )
-        assert lut.LUTDescriptor == [len(self._lut_data), first_value, 8]
-        assert lut.bits_per_entry == 8
-        assert lut.first_mapped_value == first_value
-        assert np.array_equal(lut.lut_data, self._lut_data)
-        assert not hasattr(lut, 'LUTExplanation')
+    # Commented out until 8 bit LUTs are reimplemented
+    # def test_construction(self):
+    #     first_value = 0
+    #     lut = LUT(
+    #         first_mapped_value=first_value,
+    #         lut_data=self._lut_data,
+    #     )
+    #     assert lut.LUTDescriptor == [len(self._lut_data), first_value, 8]
+    #     assert lut.bits_per_entry == 8
+    #     assert lut.first_mapped_value == first_value
+    #     assert np.array_equal(lut.lut_data, self._lut_data)
+    #     assert not hasattr(lut, 'LUTExplanation')
 
     def test_construction_16bit(self):
         first_value = 0
@@ -147,13 +148,13 @@ class TestLUT(TestCase):
         first_value = 0
         lut = LUT(
             first_mapped_value=first_value,
-            lut_data=self._lut_data,
+            lut_data=self._lut_data_16,
             lut_explanation=self._explanation
         )
-        assert lut.LUTDescriptor == [len(self._lut_data), first_value, 8]
-        assert lut.bits_per_entry == 8
+        assert lut.LUTDescriptor == [len(self._lut_data), first_value, 16]
+        assert lut.bits_per_entry == 16
         assert lut.first_mapped_value == first_value
-        assert np.array_equal(lut.lut_data, self._lut_data)
+        assert np.array_equal(lut.lut_data, self._lut_data_16)
         assert lut.LUTExplanation == self._explanation
 
 
@@ -165,19 +166,20 @@ class TestModalityLUT(TestCase):
         self._lut_data_16 = np.arange(510, 600, dtype=np.uint16)
         self._explanation = 'My LUT'
 
-    def test_construction(self):
-        first_value = 0
-        lut = ModalityLUT(
-            lut_type=RescaleTypeValues.HU,
-            first_mapped_value=first_value,
-            lut_data=self._lut_data,
-        )
-        assert lut.ModalityLUTType == RescaleTypeValues.HU.value
-        assert lut.LUTDescriptor == [len(self._lut_data), first_value, 8]
-        assert lut.bits_per_entry == 8
-        assert lut.first_mapped_value == first_value
-        assert np.array_equal(lut.lut_data, self._lut_data)
-        assert not hasattr(lut, 'LUTExplanation')
+    # Commented out until 8 bit LUTs are reimplemented
+    # def test_construction(self):
+    #     first_value = 0
+    #     lut = ModalityLUT(
+    #         lut_type=RescaleTypeValues.HU,
+    #         first_mapped_value=first_value,
+    #         lut_data=self._lut_data,
+    #     )
+    #     assert lut.ModalityLUTType == RescaleTypeValues.HU.value
+    #     assert lut.LUTDescriptor == [len(self._lut_data), first_value, 8]
+    #     assert lut.bits_per_entry == 8
+    #     assert lut.first_mapped_value == first_value
+    #     assert np.array_equal(lut.lut_data, self._lut_data)
+    #     assert not hasattr(lut, 'LUTExplanation')
 
     def test_construction_16bit(self):
         first_value = 0
@@ -187,7 +189,7 @@ class TestModalityLUT(TestCase):
             lut_data=self._lut_data_16
         )
         assert lut.ModalityLUTType == RescaleTypeValues.HU.value
-        assert lut.LUTDescriptor == [len(self._lut_data), first_value, 16]
+        assert lut.LUTDescriptor == [len(self._lut_data_16), first_value, 16]
         assert lut.bits_per_entry == 16
         assert lut.first_mapped_value == first_value
         assert np.array_equal(lut.lut_data, self._lut_data_16)
@@ -199,11 +201,11 @@ class TestModalityLUT(TestCase):
         lut = ModalityLUT(
             lut_type=lut_type,
             first_mapped_value=first_value,
-            lut_data=self._lut_data
+            lut_data=self._lut_data_16
         )
         assert lut.ModalityLUTType == lut_type
-        assert lut.LUTDescriptor == [len(self._lut_data), first_value, 8]
-        assert np.array_equal(lut.lut_data, self._lut_data)
+        assert lut.LUTDescriptor == [len(self._lut_data_16), first_value, 16]
+        assert np.array_equal(lut.lut_data, self._lut_data_16)
         assert not hasattr(lut, 'LUTExplanation')
 
     def test_construction_with_exp(self):
@@ -211,12 +213,12 @@ class TestModalityLUT(TestCase):
         lut = ModalityLUT(
             lut_type=RescaleTypeValues.HU,
             first_mapped_value=first_value,
-            lut_data=self._lut_data,
+            lut_data=self._lut_data_16,
             lut_explanation=self._explanation
         )
         assert lut.ModalityLUTType == RescaleTypeValues.HU.value
-        assert lut.LUTDescriptor == [len(self._lut_data), first_value, 8]
-        assert np.array_equal(lut.lut_data, self._lut_data)
+        assert lut.LUTDescriptor == [len(self._lut_data_16), first_value, 16]
+        assert np.array_equal(lut.lut_data, self._lut_data_16)
         assert lut.LUTExplanation == self._explanation
 
     def test_construction_empty_data(self):
@@ -232,7 +234,7 @@ class TestModalityLUT(TestCase):
             ModalityLUT(
                 lut_type=RescaleTypeValues.HU,
                 first_mapped_value=-1,  # invalid
-                lut_data=self._lut_data,
+                lut_data=self._lut_data_16,
             )
 
     def test_construction_wrong_dtype(self):
@@ -630,7 +632,7 @@ class TestVOILUTTransformation(TestCase):
         super().setUp()
         self._lut = VOILUT(
             first_mapped_value=0,
-            lut_data=np.array([10, 11, 12], np.uint8)
+            lut_data=np.array([10, 11, 12], np.uint16)
         )
 
     def test_construction_basic(self):
@@ -895,26 +897,28 @@ class TestPaletteColorLUT(TestCase):
         assert lut.lut_data.dtype == np.uint16
         np.array_equal(lut.lut_data, lut_data)
 
-    def test_construction_8bit(self):
-        lut_data = np.arange(0, 256, dtype=np.uint8)
-        first_mapped_value = 0
-        lut = PaletteColorLUT(first_mapped_value, lut_data, color='blue')
+    # Commented out until 8 bit LUTs are reimplemented
+    # def test_construction_8bit(self):
+    #     lut_data = np.arange(0, 256, dtype=np.uint8)
+    #     first_mapped_value = 0
+    #     lut = PaletteColorLUT(first_mapped_value, lut_data, color='blue')
 
-        assert len(lut.BluePaletteColorLookupTableDescriptor) == 3
-        assert lut.BluePaletteColorLookupTableDescriptor[0] == 256
-        assert lut.BluePaletteColorLookupTableDescriptor[1] == 0
-        assert lut.BluePaletteColorLookupTableDescriptor[2] == 8
-        assert not hasattr(lut, 'RedPaletteColorLookupTableDescriptor')
-        assert not hasattr(lut, 'GreenPaletteColorLookupTableDescriptor')
-        assert len(lut.BluePaletteColorLookupTableData) == lut_data.shape[0] * 2
-        assert not hasattr(lut, 'RedPaletteColorLookupTableData')
-        assert not hasattr(lut, 'GreenPaletteColorLookupTableData')
+    #     assert len(lut.BluePaletteColorLookupTableDescriptor) == 3
+    #     assert lut.BluePaletteColorLookupTableDescriptor[0] == 256
+    #     assert lut.BluePaletteColorLookupTableDescriptor[1] == 0
+    #     assert lut.BluePaletteColorLookupTableDescriptor[2] == 8
+    #     assert not hasattr(lut, 'RedPaletteColorLookupTableDescriptor')
+    #     assert not hasattr(lut, 'GreenPaletteColorLookupTableDescriptor')
+    #     expected_len = lut_data.shape[0] * 2
+    #     assert len(lut.BluePaletteColorLookupTableData) == expected_len
+    #     assert not hasattr(lut, 'RedPaletteColorLookupTableData')
+    #     assert not hasattr(lut, 'GreenPaletteColorLookupTableData')
 
-        assert lut.number_of_entries == lut_data.shape[0]
-        assert lut.first_mapped_value == first_mapped_value
-        assert lut.bits_per_entry == 8
-        assert lut.lut_data.dtype == np.uint8
-        np.array_equal(lut.lut_data, lut_data)
+    #     assert lut.number_of_entries == lut_data.shape[0]
+    #     assert lut.first_mapped_value == first_mapped_value
+    #     assert lut.bits_per_entry == 8
+    #     assert lut.lut_data.dtype == np.uint8
+    #     np.array_equal(lut.lut_data, lut_data)
 
 
 class TestPaletteColorLUTTransformation(TestCase):
@@ -995,20 +999,21 @@ class TestPaletteColorLUTTransformation(TestCase):
                 blue_lut=b_lut,
             )
 
-    def test_construction_different_dtypes(self):
-        r_lut_data = np.arange(10, 120, dtype=np.uint8)
-        g_lut_data = np.arange(20, 130, dtype=np.uint16)
-        b_lut_data = np.arange(30, 140, dtype=np.uint16)
-        first_mapped_value = 32
-        r_lut = PaletteColorLUT(first_mapped_value, r_lut_data, color='red')
-        g_lut = PaletteColorLUT(first_mapped_value, g_lut_data, color='green')
-        b_lut = PaletteColorLUT(first_mapped_value, b_lut_data, color='blue')
-        with pytest.raises(ValueError):
-            PaletteColorLUTTransformation(
-                red_lut=r_lut,
-                green_lut=g_lut,
-                blue_lut=b_lut,
-            )
+    # Commented out until 8 bit LUTs are reimplemented
+    # def test_construction_different_dtypes(self):
+    #     r_lut_data = np.arange(10, 120, dtype=np.uint8)
+    #     g_lut_data = np.arange(20, 130, dtype=np.uint16)
+    #     b_lut_data = np.arange(30, 140, dtype=np.uint16)
+    #     first_mapped_value = 32
+    #     r_lut = PaletteColorLUT(first_mapped_value, r_lut_data, color='red')
+    #     g_lut = PaletteColorLUT(first_mapped_value, g_lut_data, color='green')
+    #     b_lut = PaletteColorLUT(first_mapped_value, b_lut_data, color='blue')
+    #     with pytest.raises(ValueError):
+    #         PaletteColorLUTTransformation(
+    #             red_lut=r_lut,
+    #             green_lut=g_lut,
+    #             blue_lut=b_lut,
+    #         )
 
     def test_construction_different_first_values(self):
         r_lut_data = np.arange(10, 120, dtype=np.uint16)

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 from io import BytesIO
 from pathlib import Path
 
-
 import numpy as np
 import pytest
 from PIL.ImageCms import ImageCmsProfile
@@ -55,7 +54,7 @@ class TestSoftcopyVOILUTTransformation(unittest.TestCase):
         super().setUp()
         self._lut = VOILUT(
             first_mapped_value=0,
-            lut_data=np.array([10, 11, 12], np.uint8)
+            lut_data=np.array([10, 11, 12], np.uint16)
         )
         self._ct_series = [
             dcmread(f)
@@ -799,7 +798,7 @@ class TestAdvancedBlending(unittest.TestCase):
                             0, 1, 0,
                             1, 255, 0,
                         ],
-                        dtype=np.uint8
+                        dtype=np.uint16
                     ),
                     color='red'
                 ),
@@ -810,7 +809,7 @@ class TestAdvancedBlending(unittest.TestCase):
                             0, 1, 0,
                             1, 255, 0,
                         ],
-                        dtype=np.uint8
+                        dtype=np.uint16
                     ),
                     color='green'
                 ),
@@ -821,7 +820,7 @@ class TestAdvancedBlending(unittest.TestCase):
                             0, 1, 0,
                             1, 255, 255,
                         ],
-                        dtype=np.uint8
+                        dtype=np.uint16
                     ),
                     color='blue'
                 )
@@ -838,15 +837,15 @@ class TestAdvancedBlending(unittest.TestCase):
         assert len(ds.RedPaletteColorLookupTableDescriptor) == 3
         assert ds.RedPaletteColorLookupTableDescriptor[0] == 256
         assert ds.RedPaletteColorLookupTableDescriptor[1] == 0
-        assert ds.RedPaletteColorLookupTableDescriptor[2] == 8
+        assert ds.RedPaletteColorLookupTableDescriptor[2] == 16
         assert len(ds.GreenPaletteColorLookupTableDescriptor) == 3
         assert ds.GreenPaletteColorLookupTableDescriptor[0] == 256
         assert ds.GreenPaletteColorLookupTableDescriptor[1] == 0
-        assert ds.GreenPaletteColorLookupTableDescriptor[2] == 8
+        assert ds.GreenPaletteColorLookupTableDescriptor[2] == 16
         assert len(ds.BluePaletteColorLookupTableDescriptor) == 3
         assert ds.BluePaletteColorLookupTableDescriptor[0] == 256
         assert ds.BluePaletteColorLookupTableDescriptor[1] == 0
-        assert ds.BluePaletteColorLookupTableDescriptor[2] == 8
+        assert ds.BluePaletteColorLookupTableDescriptor[2] == 16
         assert len(ds.SegmentedRedPaletteColorLookupTableData) == 12
         assert len(ds.SegmentedGreenPaletteColorLookupTableData) == 12
         assert len(ds.SegmentedBluePaletteColorLookupTableData) == 12
@@ -1049,11 +1048,11 @@ class TestXSoftcopyPresentationState(unittest.TestCase):
         self._modality_lut = ModalityLUT(
             lut_type=RescaleTypeValues.HU,
             first_mapped_value=0,
-            lut_data=np.arange(256, dtype=np.uint8)
+            lut_data=np.arange(256, dtype=np.uint16)
         )
 
         self._presentation_lut = PresentationLUT(
-            lut_data=np.arange(10, 100, dtype=np.uint8),
+            lut_data=np.arange(10, 100, dtype=np.uint16),
             first_mapped_value=0
         )
 


### PR DESCRIPTION
Following considerable confusion about the details of the 8 bit LUTs in the presentation state PR (#139), this removes the ability to create or parse 8 bit LUTs until the uncertainty around them can be resolved. Following this, only 16 bit LUTs will be supported.