### PR TITLE
Fix bugs in implementation of Advanced Blending Presentation State IOD

### DIFF
--- a/src/highdicom/pr/content.py
+++ b/src/highdicom/pr/content.py
@@ -913,27 +913,23 @@ def _add_presentation_state_relationship_attributes(
     """
     # Assert referenced images are from the same series and have the same size
     ref_im = referenced_images[0]
-    ref_series_uid = ref_im.SeriesInstanceUID
-    ref_im_seq = []
+    ref_im_items_mapping = defaultdict(list)
     for im in referenced_images:
-        series_uid = im.SeriesInstanceUID
-        if series_uid != ref_series_uid:
-            raise ValueError(
-                'All referenced images must belong to the same series.'
-            )
         if im.Rows != ref_im.Rows or im.Columns != ref_im.Columns:
             raise ValueError(
                 'All referenced images must have the same dimensions.'
             )
-        ref_im_item = Dataset()
-        ref_im_item.ReferencedSOPClassUID = im.SOPClassUID
-        ref_im_item.ReferencedSOPInstanceUID = im.SOPInstanceUID
-        ref_im_seq.append(ref_im_item)
+        item = Dataset()
+        item.ReferencedSOPClassUID = im.SOPClassUID
+        item.ReferencedSOPInstanceUID = im.SOPInstanceUID
+        ref_im_items_mapping[im.SeriesInstanceUID].append(item)
 
-    ref_series_item = Dataset()
-    ref_series_item.SeriesInstanceUID = ref_series_uid
-    ref_series_item.ReferencedImageSequence = ref_im_seq
-    dataset.ReferencedSeriesSequence = [ref_series_item]
+    dataset.ReferencedSeriesSequence = []
+    for series_instance_uid, ref_images in ref_im_items_mapping.items():
+        item = Dataset()
+        item.SeriesInstanceUID = series_instance_uid
+        item.ReferencedImageSequence = ref_images
+        dataset.ReferencedSeriesSequence.append(item)
 
 
 def _add_graphic_group_annotation_layer_attributes(

--- a/src/highdicom/pr/content.py
+++ b/src/highdicom/pr/content.py
@@ -1856,24 +1856,22 @@ class AdvancedBlending(Dataset):
                 referenced_images
             )
             if len(voi_lut_transformations) > 0:
-                logger.debug(
-                    'use VOI LUT attributes from referenced images'
-                )
+                logger.debug('use VOI LUT attributes from referenced images')
                 _add_softcopy_voi_lut_attributes(
                     self,
                     referenced_images=referenced_images,
                     voi_lut_transformations=voi_lut_transformations
                 )
             else:
-                logger.debug(
-                    'no VOI LUT attributes found in referenced images'
-                )
+                logger.debug('no VOI LUT attributes found in referenced images')
 
         # Palette Color Lookup Table
+        palette_color_lut_item = Dataset()
         _add_palette_color_lookup_table_attributes(
-            self,
+            palette_color_lut_item,
             palette_color_lut_transformation=palette_color_lut_transformation
         )
+        self.PaletteColorLookupTableSequence = [palette_color_lut_item]
 
 
 class BlendingDisplayInput(Dataset):

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -784,13 +784,16 @@ class TestAdvancedBlending(unittest.TestCase):
 
     def test_construction(self):
         ref_images = [self._sm_image, self._sm_image_reversed]
+        window_width = 24.
+        window_center = 12.
+
         ds = AdvancedBlending(
             referenced_images=ref_images,
             blending_input_number=1,
             voi_lut_transformations=[
                 SoftcopyVOILUTTransformation(
-                    window_center=12.,
-                    window_width=24.
+                    window_center=window_center,
+                    window_width=window_width
                 )
             ],
             palette_color_lut_transformation=PaletteColorLUTTransformation(
@@ -829,6 +832,7 @@ class TestAdvancedBlending(unittest.TestCase):
                 )
             )
         )
+
         assert isinstance(ds, Dataset)
         assert ds.StudyInstanceUID == ref_images[0].StudyInstanceUID
         assert ds.SeriesInstanceUID == ref_images[0].SeriesInstanceUID
@@ -838,22 +842,31 @@ class TestAdvancedBlending(unittest.TestCase):
             ref_item = ds.ReferencedImageSequence[i]
             assert ref_item.ReferencedSOPInstanceUID == ref_im.SOPInstanceUID
         assert ds.BlendingInputNumber == 1
+
         assert len(ds.SoftcopyVOILUTSequence) == 1
-        assert len(ds.RedPaletteColorLookupTableDescriptor) == 3
-        assert ds.RedPaletteColorLookupTableDescriptor[0] == 256
-        assert ds.RedPaletteColorLookupTableDescriptor[1] == 0
-        assert ds.RedPaletteColorLookupTableDescriptor[2] == 16
-        assert len(ds.GreenPaletteColorLookupTableDescriptor) == 3
-        assert ds.GreenPaletteColorLookupTableDescriptor[0] == 256
-        assert ds.GreenPaletteColorLookupTableDescriptor[1] == 0
-        assert ds.GreenPaletteColorLookupTableDescriptor[2] == 16
-        assert len(ds.BluePaletteColorLookupTableDescriptor) == 3
-        assert ds.BluePaletteColorLookupTableDescriptor[0] == 256
-        assert ds.BluePaletteColorLookupTableDescriptor[1] == 0
-        assert ds.BluePaletteColorLookupTableDescriptor[2] == 16
-        assert len(ds.SegmentedRedPaletteColorLookupTableData) == 12
-        assert len(ds.SegmentedGreenPaletteColorLookupTableData) == 12
-        assert len(ds.SegmentedBluePaletteColorLookupTableData) == 12
+        item = ds.SoftcopyVOILUTSequence[0]
+        assert item.WindowWidth == window_width
+        assert item.WindowCenter == window_center
+        assert not hasattr(item, 'VOILUTSequence')
+
+        assert len(ds.PaletteColorLookupTableSequence) == 1
+        item = ds.PaletteColorLookupTableSequence[0]
+        assert len(item.RedPaletteColorLookupTableDescriptor) == 3
+        assert item.RedPaletteColorLookupTableDescriptor[0] == 256
+        assert item.RedPaletteColorLookupTableDescriptor[1] == 0
+        assert item.RedPaletteColorLookupTableDescriptor[2] == 16
+        assert len(item.GreenPaletteColorLookupTableDescriptor) == 3
+        assert item.GreenPaletteColorLookupTableDescriptor[0] == 256
+        assert item.GreenPaletteColorLookupTableDescriptor[1] == 0
+        assert item.GreenPaletteColorLookupTableDescriptor[2] == 16
+        assert len(item.BluePaletteColorLookupTableDescriptor) == 3
+        assert item.BluePaletteColorLookupTableDescriptor[0] == 256
+        assert item.BluePaletteColorLookupTableDescriptor[1] == 0
+        assert item.BluePaletteColorLookupTableDescriptor[2] == 16
+        assert len(item.SegmentedRedPaletteColorLookupTableData) == 12
+        assert len(item.SegmentedGreenPaletteColorLookupTableData) == 12
+        assert len(item.SegmentedBluePaletteColorLookupTableData) == 12
+
         assert not hasattr(ds, 'ContentDescription')
         assert not hasattr(ds, 'ConceptNameCodeSequence')
         assert not hasattr(ds, 'ThresholdSequence')


### PR DESCRIPTION
There is currently a check that prevents reference of images from more than one series in presentation state instances. However, in case of the DICOM Advanced Blending Representation State IOD, images from more than one series may be blended together (as long as the images are defined in the same frame of reference). This PR relaxes the check to allow the referencing images from multiple series.

The PR also fixes the inclusion of attributes of the Palette Color Lookup Table Macro in the Advanced Blending Sequence. The attributes should be added to an item of the Palette Color Lookup Table Sequence rather than the item of the Advanced Blending Sequence.