### PR TITLE
Add warning when empty segmentation is passed with omit_empty_frames

### DIFF
--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -6,7 +6,6 @@ from os import PathLike
 from typing import (
     Any, cast, Dict, List, Optional, Sequence, Union, Tuple, BinaryIO
 )
-import warnings
 
 import numpy as np
 from pydicom.dataset import Dataset
@@ -538,11 +537,10 @@ class Segmentation(SOPClass):
         self.SegmentsOverlap = segments_overlap.value
         if omit_empty_frames and pixel_array.sum() == 0:
             omit_empty_frames = False
-            warnings.warn(
+            logger.warning(
                 'Encoding an empty segmentation with "omit_empty_frames" '
                 'set to True. Reverting to encoding all frames since omitting '
-                'all frames is not possible.',
-                UserWarning
+                'all frames is not possible.'
             )
 
         if plane_positions is None:

--- a/src/highdicom/seg/sop.py
+++ b/src/highdicom/seg/sop.py
@@ -6,6 +6,7 @@ from os import PathLike
 from typing import (
     Any, cast, Dict, List, Optional, Sequence, Union, Tuple, BinaryIO
 )
+import warnings
 
 import numpy as np
 from pydicom.dataset import Dataset
@@ -535,6 +536,14 @@ class Segmentation(SOPClass):
             segmentation_type
         )
         self.SegmentsOverlap = segments_overlap.value
+        if omit_empty_frames and pixel_array.sum() == 0:
+            omit_empty_frames = False
+            warnings.warn(
+                'Encoding an empty segmentation with "omit_empty_frames" '
+                'set to True. Reverting to encoding all frames since omitting '
+                'all frames is not possible.',
+                UserWarning
+            )
 
         if plane_positions is None:
             if pixel_array.shape[0] != len(source_plane_positions):

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -1652,6 +1652,52 @@ class TestSegmentation(unittest.TestCase):
                 device_serial_number=self._device_serial_number
             )
 
+    def test_construction_empty_source_seg_sparse(self):
+        # Can encoding an empty segmentation with omit_empty_frames=True issues
+        # a warning and encodes the full segmentation
+        empty_pixel_array = np.zeros_like(self._ct_pixel_array)
+        with pytest.warns(UserWarning):
+            seg = Segmentation(
+                source_images=[self._ct_image],
+                pixel_array=empty_pixel_array,
+                segmentation_type=SegmentationTypeValues.FRACTIONAL.value,
+                segment_descriptions=(
+                    self._segment_descriptions
+                ),
+                series_instance_uid=self._series_instance_uid,
+                series_number=self._series_number,
+                sop_instance_uid=self._sop_instance_uid,
+                instance_number=self._instance_number,
+                manufacturer=self._manufacturer,
+                manufacturer_model_name=self._manufacturer_model_name,
+                software_versions=self._software_versions,
+                device_serial_number=self._device_serial_number,
+                omit_empty_frames=True,
+            )
+
+        assert seg.pixel_array.shape == empty_pixel_array.shape
+
+    def test_construction_empty_seg_image(self):
+        # Can encode an empty segmentation with omit_empty_frames=False
+        empty_pixel_array = np.zeros_like(self._ct_pixel_array)
+        Segmentation(
+            source_images=[self._ct_image],
+            pixel_array=empty_pixel_array,
+            segmentation_type=SegmentationTypeValues.FRACTIONAL.value,
+            segment_descriptions=(
+                self._segment_descriptions
+            ),
+            series_instance_uid=self._series_instance_uid,
+            series_number=self._series_number,
+            sop_instance_uid=self._sop_instance_uid,
+            instance_number=self._instance_number,
+            manufacturer=self._manufacturer,
+            manufacturer_model_name=self._manufacturer_model_name,
+            software_versions=self._software_versions,
+            device_serial_number=self._device_serial_number,
+            omit_empty_frames=False,
+        )
+
     def test_construction_invalid_content_label(self):
         with pytest.raises(ValueError):
             Segmentation(

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -1656,24 +1656,23 @@ class TestSegmentation(unittest.TestCase):
         # Can encoding an empty segmentation with omit_empty_frames=True issues
         # a warning and encodes the full segmentation
         empty_pixel_array = np.zeros_like(self._ct_pixel_array)
-        with pytest.warns(UserWarning):
-            seg = Segmentation(
-                source_images=[self._ct_image],
-                pixel_array=empty_pixel_array,
-                segmentation_type=SegmentationTypeValues.FRACTIONAL.value,
-                segment_descriptions=(
-                    self._segment_descriptions
-                ),
-                series_instance_uid=self._series_instance_uid,
-                series_number=self._series_number,
-                sop_instance_uid=self._sop_instance_uid,
-                instance_number=self._instance_number,
-                manufacturer=self._manufacturer,
-                manufacturer_model_name=self._manufacturer_model_name,
-                software_versions=self._software_versions,
-                device_serial_number=self._device_serial_number,
-                omit_empty_frames=True,
-            )
+        seg = Segmentation(
+            source_images=[self._ct_image],
+            pixel_array=empty_pixel_array,
+            segmentation_type=SegmentationTypeValues.FRACTIONAL.value,
+            segment_descriptions=(
+                self._segment_descriptions
+            ),
+            series_instance_uid=self._series_instance_uid,
+            series_number=self._series_number,
+            sop_instance_uid=self._sop_instance_uid,
+            instance_number=self._instance_number,
+            manufacturer=self._manufacturer,
+            manufacturer_model_name=self._manufacturer_model_name,
+            software_versions=self._software_versions,
+            device_serial_number=self._device_serial_number,
+            omit_empty_frames=True,
+        )
 
         assert seg.pixel_array.shape == empty_pixel_array.shape
 


### PR DESCRIPTION
Addresses #180 

When the `omit_empty_frames` option is used for a Segmentation and an empty segmentation mask is passed (i.e. a mask with all zeros), the constructor will issue a `UserWarning` and ignore the `omit_empty_frames` option.

Add tests