### PR TITLE
Minor fix to read_frame docstring

### DIFF
--- a/src/highdicom/io.py
+++ b/src/highdicom/io.py
@@ -557,7 +557,7 @@ class ImageFileReader(object):
         correct_color: bool, optional
             Whether colors should be corrected by applying an ICC
             transformation. Will only be performed if metadata contain an
-            ICC Profile.
+            ICC Profile. Default = True.
 
         Returns
         -------


### PR DESCRIPTION
Added default value in `correct_color` description