### PR TITLE
Improve check for coordinates in annotations group

### DIFF
--- a/src/highdicom/ann/content.py
+++ b/src/highdicom/ann/content.py
@@ -308,7 +308,7 @@ class AnnotationGroup(Dataset):
                         f'Graphic data of annotation #{i + 1} of graphic type '
                         '"POLYGON" must be at least three coordinates.'
                     )
-                if np.allclose(graphic_data[i][0], graphic_data[i][-1]):
+                if np.array_equal(graphic_data[i][0], graphic_data[i][-1]):
                     raise ValueError(
                         'The first and last coordinate of graphic data of '
                         f'annotation #{i + 1} of graphic type "POLYGON" '


### PR DESCRIPTION
Currently, the constructor of `highdicom.ann.AnnotationGroup` checks whether the coordinates passed via `graphic_data` are structured correctly. Specifically, it checks whether the first and last point of a POLYGON are identical (this is required by SR but not by ANN). However, it does not directly compare the floating point values for equivalence, but checks whether they are close. This can lead to an exception in case the coordinates are indeed very close to each other.