### PR TITLE
Allow annotations to reference multiple images

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
-mypy==0.910
-pytest==6.2.4
-pytest-cov==2.12.1
-pytest-flake8==1.0.7
+mypy==0.971
+pytest==7.1.2
+pytest-cov==3.0.0
+pytest-flake8==1.1.1
 git+https://github.com/numpy/numpy-stubs@201115370a0c011d879d69068b60509accc7f750#egg=numpy-stubs

--- a/src/highdicom/ann/sop.py
+++ b/src/highdicom/ann/sop.py
@@ -99,12 +99,6 @@ class MicroscopyBulkSimpleAnnotations(SOPClass):
 
         """  # noqa: E501
         src_img = source_images[0]
-        is_multiframe = hasattr(src_img, 'NumberOfFrames')
-        if is_multiframe and len(source_images) > 1:
-            raise ValueError(
-                'Only one source image should be provided in case images '
-                'are multi-frame images.'
-            )
 
         supported_transfer_syntaxes = {
             ImplicitVRLittleEndian,

--- a/src/highdicom/ann/sop.py
+++ b/src/highdicom/ann/sop.py
@@ -105,7 +105,7 @@ class MicroscopyBulkSimpleAnnotations(SOPClass):
         coordinate_type = AnnotationCoordinateTypeValues(
             annotation_coordinate_type
         )
-        if len(set([img.FrameOfReferenceUID for img in source_images])) > 1:
+        if len({img.FrameOfReferenceUID for img in source_images}) > 1:
             raise ValueError(
                 'All source images must have the same Frame of Reference UID.'
             )

--- a/src/highdicom/ann/sop.py
+++ b/src/highdicom/ann/sop.py
@@ -57,7 +57,11 @@ class MicroscopyBulkSimpleAnnotations(SOPClass):
         Parameters
         ----------
         source_images: Sequence[pydicom.dataset.Dataset]
-            Image instances from which annotations were derived
+            Image instances from which annotations were derived. In case of
+            "2D" Annotation Coordinate Type, only one source image shall be
+            provided. In case of "3D" Annotation Coordinate Type, one or more
+            source images may be provided. All images shall have the same
+            Frame of Reference UID.
         annotation_coordinate_type: Union[str, highdicom.ann.AnnotationCoordinateTypeValues]
             Type of coordinates (two-dimensional coordinates relative to origin
             of Total Pixel Matrix in pixel unit or three-dimensional
@@ -98,6 +102,21 @@ class MicroscopyBulkSimpleAnnotations(SOPClass):
             of `highdicom.base.SOPClass`
 
         """  # noqa: E501
+        coordinate_type = AnnotationCoordinateTypeValues(
+            annotation_coordinate_type
+        )
+        if len(set([img.FrameOfReferenceUID for img in source_images])) > 1:
+            raise ValueError(
+                'All source images must have the same Frame of Reference UID.'
+            )
+        if len(source_images) == 0:
+            raise ValueError('At least one source image must be provided.')
+        elif len(source_images) > 1:
+            if coordinate_type == AnnotationCoordinateTypeValues.SCOORD:
+                raise ValueError(
+                    'Only one source image should be provided '
+                    'if Annotation Coordinate Type is "2D".'
+                )
         src_img = source_images[0]
 
         supported_transfer_syntaxes = {
@@ -149,9 +168,6 @@ class MicroscopyBulkSimpleAnnotations(SOPClass):
             check_person_name(content_creator_name)
         self.ContentCreatorName = content_creator_name
 
-        coordinate_type = AnnotationCoordinateTypeValues(
-            annotation_coordinate_type
-        )
         self.AnnotationCoordinateType = coordinate_type.value
         if coordinate_type == AnnotationCoordinateTypeValues.SCOORD:
             pixel_origin_interpretation = PixelOriginInterpretationValues(
@@ -172,15 +188,19 @@ class MicroscopyBulkSimpleAnnotations(SOPClass):
                 'value.'
             )
 
+        ref = Dataset()
+        ref.ReferencedSOPClassUID = src_img.SOPClassUID
+        ref.ReferencedSOPInstanceUID = src_img.SOPInstanceUID
+        self.ReferencedImageSequence = [ref]
+
         # Common Instance Reference
         self.ReferencedImageSequence: List[Dataset] = []
         referenced_series: Dict[str, List[Dataset]] = defaultdict(list)
-        for s_img in source_images:
+        for img in source_images:
             ref = Dataset()
-            ref.ReferencedSOPClassUID = s_img.SOPClassUID
-            ref.ReferencedSOPInstanceUID = s_img.SOPInstanceUID
-            self.ReferencedImageSequence.append(ref)
-            referenced_series[s_img.SeriesInstanceUID].append(ref)
+            ref.ReferencedSOPClassUID = img.SOPClassUID
+            ref.ReferencedSOPInstanceUID = img.SOPInstanceUID
+            referenced_series[img.SeriesInstanceUID].append(ref)
 
         self.ReferencedSeriesSequence: List[Dataset] = []
         for series_instance_uid, referenced_images in referenced_series.items():

--- a/src/highdicom/sr/content.py
+++ b/src/highdicom/sr/content.py
@@ -842,8 +842,8 @@ class ImageRegion3D(Scoord3DContentItem):
 
 class VolumeSurface(ContentSequence):
 
-    """Content sequence representing a volume surface in the the three-dimensional
-    patient/slide coordinate system in millimeter unit.
+    """Content sequence representing a volume surface in the the
+    three-dimensional patient/slide coordinate system in millimeter unit.
     """
 
     def __init__(

--- a/src/highdicom/sr/utils.py
+++ b/src/highdicom/sr/utils.py
@@ -289,7 +289,7 @@ def collect_evidence(
         else:
             unref_group[key].append(evd_item)
         evd_uids.add(evd.SOPInstanceUID)
-    if not(ref_uids.issubset(evd_uids)):
+    if not ref_uids.issubset(evd_uids):
         missing_uids = ref_uids.difference(evd_uids)
         raise ValueError(
             'No evidence was provided for the following SOP instances, '

--- a/src/highdicom/utils.py
+++ b/src/highdicom/utils.py
@@ -121,7 +121,7 @@ def compute_plane_position_tiled_full(
         slice_index is not None,
         spacing_between_slices is not None,
     )
-    if not(sum(provided_3d_params) == 0 or sum(provided_3d_params) == 2):
+    if not (sum(provided_3d_params) == 0 or sum(provided_3d_params) == 2):
         raise TypeError(
             'None or both of the following parameters need to be provided: '
             '"slice_index", "spacing_between_slices"'


### PR DESCRIPTION
An annotations object may contain multiple measurements, which may have been derived from different images. Therefore, it is important to allow reference of multiple (multi-frame) image instances.