### PR TITLE
Allow reference of optical path for annotations measurements

### DIFF
--- a/src/highdicom/ann/content.py
+++ b/src/highdicom/ann/content.py
@@ -11,7 +11,10 @@ from highdicom.ann.enum import (
     AnnotationGroupGenerationTypeValues,
     GraphicTypeValues,
 )
-from highdicom.content import AlgorithmIdentificationSequence
+from highdicom.content import (
+    AlgorithmIdentificationSequence,
+    ReferencedImageSequence,
+)
 from highdicom.sr.coding import CodedConcept
 from highdicom.uid import UID
 from highdicom._module_utils import check_required_attributes
@@ -25,7 +28,8 @@ class Measurements(Dataset):
         self,
         name: Union[Code, CodedConcept],
         values: np.ndarray,
-        unit: Union[Code, CodedConcept]
+        unit: Union[Code, CodedConcept],
+        referenced_images: Optional[ReferencedImageSequence] = None
     ) -> None:
         """
         Parameters
@@ -40,6 +44,9 @@ class Measurements(Dataset):
         unit: Union[highdicom.sr.CodedConcept, pydicom.sr.coding.Code], optional
             Coded units of measurement (see :dcm:`CID 7181 <part16/sect_CID_7181.html>`
             "Abstract Multi-dimensional Image Model Component Units")
+        referenced_images: Union[highdicom.ReferencedImageSequence, None], optional
+            Referenced image to which the measurement applies. Should only be
+            provided for intensity measurements.
 
         """  # noqa: E501
         super().__init__()
@@ -60,6 +67,22 @@ class Measurements(Dataset):
             stored_indices = (np.where(~is_nan)[0] + 1).astype(np.int32)
             item.AnnotationIndexList = stored_indices.tobytes()
         self.MeasurementValuesSequence = [item]
+
+        if referenced_images is not None:
+            if len(referenced_images) == 0:
+                raise ValueError(
+                    'Argument "referenced_images" must contain one item.'
+                )
+            elif len(referenced_images) > 1:
+                raise ValueError(
+                    'Argument "referenced_images" must contain only one item.'
+                )
+            if not isinstance(referenced_images, ReferencedImageSequence):
+                raise TypeError(
+                    'Argument "referenced_images" must have type '
+                    'ReferencedImageSequence.'
+                )
+            self.ReferencedImageSequence = referenced_images
 
     @property
     def name(self) -> CodedConcept:
@@ -520,6 +543,12 @@ class AnnotationGroup(Dataset):
                 )
         else:
             if coordinate_type == AnnotationCoordinateTypeValues.SCOORD:
+                if hasattr(self, 'CommonZCoordinateValue'):
+                    raise ValueError(
+                        'The annotation group contains the '
+                        '"Common Z Coordinate Value" element and therefore '
+                        'cannot have Annotation Coordinate Type "2D".'
+                    )
                 coordinate_dimensionality = 2
             else:
                 coordinate_dimensionality = 3

--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -10,7 +10,10 @@ from pydicom.sequence import Sequence as DataElementSequence
 from pydicom.sr.coding import Code
 from pydicom.sr.codedict import codes
 from pydicom.valuerep import DS, format_number_as_ds
-from pydicom._storage_sopclass_uids import SegmentationStorage
+from pydicom.uid import (
+    SegmentationStorage,
+    VLWholeSlideMicroscopyImageStorage,
+)
 
 from highdicom.enum import (
     CoordinateSystemNames,
@@ -1406,21 +1409,20 @@ class ReferencedImageSequence(DataElementSequence):
         referenced_images: Optional[Sequence[Dataset]] = None,
         referenced_frame_number: Union[int, Sequence[int], None] = None,
         referenced_segment_number: Union[int, Sequence[int], None] = None,
+        referenced_optical_path_identifier: Union[int, None] = None,
     ):
         """
 
         Parameters
         ----------
         referenced_images: Union[Sequence[pydicom.Dataset], None], optional
-            Images to which the VOI LUT described in this dataset applies. Note
-            that if unspecified, the VOI LUT applies to every image referenced
-            in the presentation state object that this dataset is included in.
+            Images that should be referenced
         referenced_frame_number: Union[int, Sequence[int], None], optional
-            Frame number(s) within a referenced multiframe image to which this
-            VOI LUT applies.
+            Frame number(s) within a referenced multiframe image
         referenced_segment_number: Union[int, Sequence[int], None], optional
-            Segment number(s) within a referenced segmentation image to which
-            this VOI LUT applies.
+            Segment number(s) within a referenced segmentation image
+        referenced_optical_path_identifier: Union[int, None], optional
+            Identifier of the optical path within a referenced microscopy image
 
         """
         super().__init__()
@@ -1445,6 +1447,7 @@ class ReferencedImageSequence(DataElementSequence):
             raise ValueError("Found duplicate instances in referenced images.")
 
         multiple_images = len(referenced_images) > 1
+        sop_class_uid = referenced_images[0].SOPClassUID
         if referenced_frame_number is not None:
             if multiple_images:
                 raise ValueError(
@@ -1466,16 +1469,17 @@ class ReferencedImageSequence(DataElementSequence):
                         f'Frame number {f} is invalid for referenced '
                         'image.'
                     )
+
         if referenced_segment_number is not None:
             if multiple_images:
                 raise ValueError(
                     'Specifying "referenced_segment_number" is not '
                     'supported with multiple referenced images.'
                 )
-            if referenced_images[0].SOPClassUID != SegmentationStorage:
+            if sop_class_uid != SegmentationStorage:
                 raise TypeError(
                     '"referenced_segment_number" is only valid when the '
-                    'referenced image is a segmentation image.'
+                    'referenced image is a Segmentation image.'
                 )
             number_of_segments = len(referenced_images[0].SegmentSequence)
             if isinstance(referenced_segment_number, Sequence):
@@ -1485,8 +1489,7 @@ class ReferencedImageSequence(DataElementSequence):
             for s in _referenced_segment_numbers:
                 if s < 1 or s > number_of_segments:
                     raise ValueError(
-                        f'Segment number {s} is invalid for referenced '
-                        'image.'
+                        f'Segment number {s} is invalid for referenced image.'
                     )
             if referenced_frame_number is not None:
                 # Check that the one of the specified segments exists
@@ -1504,6 +1507,31 @@ class ReferencedImageSequence(DataElementSequence):
                             f'Referenced frame {f} does not contain any of '
                             'the referenced segments.'
                         )
+
+        if referenced_optical_path_identifier is not None:
+            if multiple_images:
+                raise ValueError(
+                    'Specifying "referenced_optical_path_identifier" is not '
+                    'supported with multiple referenced images.'
+                )
+            if sop_class_uid != VLWholeSlideMicroscopyImageStorage:
+                raise TypeError(
+                    '"referenced_optical_path_identifier" is only valid when '
+                    'referenced image is a VL Whole Slide Microscopy image.'
+                )
+            has_optical_path = False
+            for ref_img in referenced_images:
+                for optical_path_item in ref_img.OpticalPathSequence:
+                    has_optical_path |= (
+                        optical_path_item.OpticalPathIdentifier ==
+                        referenced_optical_path_identifier
+                    )
+            if not has_optical_path:
+                raise ValueError(
+                    'None of the reference images contains the specified '
+                    '"referenced_optical_path_identifier".'
+                )
+
         for im in referenced_images:
             if not does_iod_have_pixel_data(im.SOPClassUID):
                 raise ValueError(
@@ -1515,6 +1543,9 @@ class ReferencedImageSequence(DataElementSequence):
             ref_im.ReferencedSOPClassUID = im.SOPClassUID
             if referenced_segment_number is not None:
                 ref_im.ReferencedSegmentNumber = referenced_segment_number
+            elif referenced_optical_path_identifier is not None:
+                ref_im.ReferencedOpticalPathIdentifier = \
+                    str(referenced_optical_path_identifier)
             if referenced_frame_number is not None:
                 ref_im.ReferencedFrameNumber = referenced_frame_number
             self.append(ref_im)

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -742,9 +742,8 @@ class TestReferencedImageSequence(TestCase):
             for f in get_testdata_files('dicomdirtests/77654033/CT2/*')
         ]
         self._ct_multiframe = dcmread(get_testdata_file('eCT_Supplemental.dcm'))
-        self._seg = dcmread(
-            'data/test_files/seg_image_ct_binary_overlap.dcm'
-        )
+        self._sm = dcmread('data/test_files/sm_image.dcm')
+        self._seg = dcmread('data/test_files/seg_image_ct_binary_overlap.dcm')
 
     def test_construction_ref_ims(self):
         ref_ims = ReferencedImageSequence(
@@ -812,9 +811,9 @@ class TestReferencedImageSequence(TestCase):
         assert ref_ims[0].ReferencedSegmentNumber == 1
 
     def test_construction_segment_number_non_seg(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             ReferencedImageSequence(
-                referenced_images=self._ct_series,
+                referenced_images=self._ct_series[0],
                 referenced_segment_number=1
             )
 
@@ -872,6 +871,37 @@ class TestReferencedImageSequence(TestCase):
             ReferencedImageSequence(
                 referenced_images=self._ct_series * 2,
             )
+
+    def test_construction_optical_path_identifier(self):
+        ref_ims = ReferencedImageSequence(
+            referenced_images=[self._sm],
+            referenced_optical_path_identifier='1'
+        )
+        assert len(ref_ims) == 1
+        assert ref_ims[0].ReferencedOpticalPathIdentifier == '1'
+
+    def test_construction_optical_path_identifier_invalid_reference(self):
+        with pytest.raises(ValueError):
+            ReferencedImageSequence(
+                referenced_images=[self._sm],
+                referenced_optical_path_identifier='20'
+            )
+
+    def test_construction_optical_path_identifier_non_sm(self):
+        with pytest.raises(TypeError):
+            ReferencedImageSequence(
+                referenced_images=[self._seg],
+                referenced_optical_path_identifier='1'
+            )
+
+    def test_construction_optical_path_identifier_and_frame_numbers(self):
+        ref_ims = ReferencedImageSequence(
+            referenced_images=[self._sm],
+            referenced_optical_path_identifier='1',
+            referenced_frame_number=[1, 2],
+        )
+        assert len(ref_ims) == 1
+        assert ref_ims[0].ReferencedOpticalPathIdentifier == '1'
 
 
 class TestPaletteColorLUT(TestCase):


### PR DESCRIPTION
In case of intensity measurements for annotations, the microscopy image (and the optical path) need to be specified for the measurements. This PR adds allows including a reference to the images to which the measurements apply.

cc @dclunie