### PR TITLE
Remove module level imports of module data to speed up module import

### DIFF
--- a/src/highdicom/_module_utils.py
+++ b/src/highdicom/_module_utils.py
@@ -3,13 +3,6 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 
 from pydicom import Dataset
 
-from highdicom._iods import IOD_MODULE_MAP, SOP_CLASS_UID_IOD_KEY_MAP
-from highdicom._modules import MODULE_ATTRIBUTE_MAP
-from highdicom._iods import (
-    IOD_MODULE_MAP,
-    SOP_CLASS_UID_IOD_KEY_MAP
-)
-
 
 # Allowed values for the type of an attribute
 class AttributeTypeValues(Enum):
@@ -168,6 +161,7 @@ def construct_module_tree(module: str) -> Dict[str, Any]:
         dictionary that forms an item in the next level of the tree structure.
 
     """
+    from highdicom._modules import MODULE_ATTRIBUTE_MAP
     if module not in MODULE_ATTRIBUTE_MAP:
         raise AttributeError(f"No such module found: '{module}'.")
     tree: Dict[str, Any] = {'attributes': {}}
@@ -205,6 +199,10 @@ def get_module_usage(
 
 
     """
+    from highdicom._iods import (
+        IOD_MODULE_MAP,
+        SOP_CLASS_UID_IOD_KEY_MAP
+    )
     try:
         iod_name = SOP_CLASS_UID_IOD_KEY_MAP[sop_class_uid]
     except KeyError as e:
@@ -235,6 +233,11 @@ def is_attribute_in_iod(attribute: str, sop_class_uid: str) -> bool:
         specified by the sop_class_uid. False otherwise.
 
     """
+    from highdicom._iods import (
+        IOD_MODULE_MAP,
+        SOP_CLASS_UID_IOD_KEY_MAP
+    )
+    from highdicom._modules import MODULE_ATTRIBUTE_MAP
     try:
         iod_name = SOP_CLASS_UID_IOD_KEY_MAP[sop_class_uid]
     except KeyError as e:

--- a/src/highdicom/base.py
+++ b/src/highdicom/base.py
@@ -16,8 +16,6 @@ from highdicom.enum import (
 )
 from highdicom.valuerep import check_person_name
 from highdicom.version import __version__
-from highdicom._iods import IOD_MODULE_MAP, SOP_CLASS_UID_IOD_KEY_MAP
-from highdicom._modules import MODULE_ATTRIBUTE_MAP
 from highdicom._module_utils import is_attribute_in_iod
 
 
@@ -289,6 +287,8 @@ class SOPClass(Dataset):
             DICOM Module (e.g., ``"General Series"`` or ``"Specimen"``)
 
         """
+        from highdicom._iods import IOD_MODULE_MAP, SOP_CLASS_UID_IOD_KEY_MAP
+        from highdicom._modules import MODULE_ATTRIBUTE_MAP
         logger.info(
             'copy {}-related attributes from dataset "{}"'.format(
                 ie, dataset.SOPInstanceUID

--- a/src/highdicom/legacy/sop.py
+++ b/src/highdicom/legacy/sop.py
@@ -17,8 +17,6 @@ from pydicom.uid import (
 
 from highdicom.base import SOPClass
 from highdicom.frame import encode_frame
-from highdicom._iods import IOD_MODULE_MAP, SOP_CLASS_UID_IOD_KEY_MAP
-from highdicom._modules import MODULE_ATTRIBUTE_MAP
 
 
 logger = logging.getLogger(__name__)
@@ -60,6 +58,8 @@ def _convert_legacy_to_enhanced(
     which instances are provided via `sf_datasets`.
 
     """
+    from highdicom._iods import IOD_MODULE_MAP, SOP_CLASS_UID_IOD_KEY_MAP
+    from highdicom._modules import MODULE_ATTRIBUTE_MAP
     try:
         ref_ds = sf_datasets[0]
     except IndexError:


### PR DESCRIPTION
As noted in #188, importing highdicom requires importing the very large data structures in `highdicom._iods` and `highdicom._modules`. This slows down imports somewhat, but more importantly slows down coverage based tests like `coverage run` very considerably when often this is unnecessary because the data will not actually be used.

This PR swaps all imports from these modules to be lazily evaluated. With this change, the test that @wyli reported took an very long time now completes almost instantaneously. Of course coverage tests that run on functions that make use of the data in these modules will still be slow, but at least now simple tests will run faster.

As far as I'm aware, there are no significant downsides to this.