### PR TITLE
Changes HAS_PROPERTIES to HAS_CONCEPT_MOD for validator error messages

### DIFF
--- a/src/highdicom/sr/templates.py
+++ b/src/highdicom/sr/templates.py
@@ -1033,7 +1033,7 @@ class MeasurementProperties(Template):
                     scheme_designator='DCM'
                 ),
                 value=normality,
-                relationship_type=RelationshipTypeValues.HAS_PROPERTIES
+                relationship_type=RelationshipTypeValues.HAS_CONCEPT_MOD
             )
             self.append(normality_item)
         if measurement_statistical_properties is not None:
@@ -1060,7 +1060,7 @@ class MeasurementProperties(Template):
                     scheme_designator='DCM'
                 ),
                 value=level_of_significance,
-                relationship_type=RelationshipTypeValues.HAS_PROPERTIES
+                relationship_type=RelationshipTypeValues.HAS_CONCEPT_MOD
             )
             self.append(level_of_significance_item)
         if selection_status is not None:


### PR DESCRIPTION
SRs created using the [highdicom example program](https://highdicom.readthedocs.io/en/latest/usage.html#creating-structured-report-sr-documents) generate errors in the pixelmed  `DicomSRValidator.sh` program:
```
./DicomSRValidator.sh ~/Development/github/merge/highdicom/highdicom_doc_sr_original.dcm 
Found Comprehensive3DSR IOD
Found Root Template TID_1500 (MeasurementReport)
Error: Template 300 Measurement/[Row 1] NUM */[Row 2] CODE *: 1.7.1.5.2: /CONTAINER (126000,DCM,"Imaging Measurement Report")/CONTAINER (126010,DCM,"Imaging Measurements")/CONTAINER (125007,DCM,"Measurement Group")/NUM (131184002,SCT,"Area of defined region")/CODE (121402,DCM,"Normality"): Incorrect relationship - expected HAS CONCEPT MOD - found HAS PROPERTIES
Error: Template 300 Measurement/[Row 1] NUM */[Row 2] CODE *: 1.7.1.5.3: /CONTAINER (126000,DCM,"Imaging Measurement Report")/CONTAINER (126010,DCM,"Imaging Measurements")/CONTAINER (125007,DCM,"Measurement Group")/NUM (131184002,SCT,"Area of defined region")/CODE (121403,DCM,"Level of Significance"): Incorrect relationship - expected HAS CONCEPT MOD - found HAS PROPERTIES
Root Template Validation Complete
IOD validation complete
```

This PR contains small changes that removes these errors by changing the relationship type from HAS_PROPERTIES to HAS_CONCEPT_MOD in two places. 
```
 ./DicomSRValidator.sh ~/Development/github/merge/highdicom/highdicom_doc_sr.dcm 
Found Comprehensive3DSR IOD
Found Root Template TID_1500 (MeasurementReport)
Root Template Validation Complete
IOD validation complete
```
(both SRs are attached for inspection). 

However - it is not clear which is correct.[ TID 300 ](https://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_A.html#sect_TID_300). The highdicom code appears to assume that the code
```
properties=hd.sr.MeasurementProperties(
            normality=hd.sr.CodedConcept(
                value="17621005",
                meaning="Normal",
                scheme_designator="SCT"
            ),
            level_of_significance=codes.SCT.NotSignificant
        )
```
is related to row 8 of the table for TID 300 which has the relationship HAS_PROPERTIES. The validator seems to assume that these properties are in ROW 2 and have the relationship HAS_CONCEPT_MOD. Which is correct? 


[sample_SRs.zip](https://github.com/herrmannlab/highdicom/files/9390328/sample_SRs.zip)

      