### PR TITLE
Make pylibjpeg-libjpeg optional

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools
         pip install -r requirements_test.txt
-        pip install .
+        pip install ".[libjpeg]"
     - name: Lint with flake8
       run: |
         flake8 --exclude='bin,build,.eggs,src/highdicom/_*'

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+        dependencies: [".", "'.[libjpeg]'"]
 
     steps:
     - uses: actions/checkout@v2
@@ -27,7 +28,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools
         pip install -r requirements_test.txt
-        pip install ".[libjpeg]"
+        pip install ${{ matrix.dependencies }}
     - name: Lint with flake8
       run: |
         flake8 --exclude='bin,build,.eggs,src/highdicom/_*'

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,13 +22,10 @@ Pre-build package available at PyPi:
 
     pip install highdicom
 
-Like the underlying ``pydicom`` package, highdicom relies on functionality
-implemented in the ``pylibjpeg-libjpeg``
-`package <https://pypi.org/project/pylibjpeg-libjpeg/>`_ for the decoding of
-DICOM images with certain transfer syntaxes. Since ``pylibjpeg-libjpeg`` is
-licensed under a copyleft GPL v3 license, it is not installed by default when
-you install highdicom. To install ``pylibjpeg-libjpeg`` along with highdicom,
-use
+The library relies on the underlying ``pydicom`` package for decoding of pixel data, which internally delegates the task to either the ``pillow`` or the ``pylibjpeg`` packages.
+Since the ``pillow`` is a dependency of *highdicom* and will automatically be installed, some transfer syntax can thus be readily decoded and encoded (baseline JPEG, JPEG-2000, JPEG-LS).
+Support for additional transfer syntaxes (e.g., lossless JPEG) requires installation of the ``pylibjpeg`` package as well as the ``pylibjpeg-libjpeg`` and ``pylibjpeg-openjpeg`` packages.
+Since ``pylibjpeg-libjpeg`` is licensed under a copyleft GPL v3 license, it is not installed by default when you install *highdicom*. To install the ``pylibjpeg`` packages along with *highdicom*, use
 
 .. code-block:: none
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,7 +22,19 @@ Pre-build package available at PyPi:
 
     pip install highdicom
 
-Source code available at Github:
+Like the underlying ``pydicom`` package, highdicom relies on functionality
+implemented in the ``pylibjpeg-libjpeg``
+`package <https://pypi.org/project/pylibjpeg-libjpeg/>`_ for the decoding of
+DICOM images with certain transfer syntaxes. Since ``pylibjpeg-libjpeg`` is
+licensed under a copyleft GPL v3 license, it is not installed by default when
+you install highdicom. To install ``pylibjpeg-libjpeg`` along with highdicom,
+use
+
+.. code-block:: none
+
+    pip install highdicom[libjpeg]
+
+Install directly from source code (available on Github):
 
 .. code-block:: none
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,7 @@ Installation guide
 Requirements
 ------------
 
-* `Python <https://www.python.org/>`_ (version 3.5 or higher)
+* `Python <https://www.python.org/>`_ (version 3.6 or higher)
 * Python package manager `pip <https://pip.pypa.io/en/stable/>`_
 
 .. _installation:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,10 +22,16 @@ Pre-build package available at PyPi:
 
     pip install highdicom
 
-The library relies on the underlying ``pydicom`` package for decoding of pixel data, which internally delegates the task to either the ``pillow`` or the ``pylibjpeg`` packages.
-Since the ``pillow`` is a dependency of *highdicom* and will automatically be installed, some transfer syntax can thus be readily decoded and encoded (baseline JPEG, JPEG-2000, JPEG-LS).
-Support for additional transfer syntaxes (e.g., lossless JPEG) requires installation of the ``pylibjpeg`` package as well as the ``pylibjpeg-libjpeg`` and ``pylibjpeg-openjpeg`` packages.
-Since ``pylibjpeg-libjpeg`` is licensed under a copyleft GPL v3 license, it is not installed by default when you install *highdicom*. To install the ``pylibjpeg`` packages along with *highdicom*, use
+The library relies on the underlying ``pydicom`` package for decoding of pixel
+data, which internally delegates the task to either the ``pillow`` or the
+``pylibjpeg`` packages. Since ``pillow`` is a dependency of *highdicom* and
+will automatically be installed, some transfer syntax can thus be readily
+decoded and encoded (baseline JPEG, JPEG-2000, JPEG-LS). Support for additional
+transfer syntaxes (e.g., lossless JPEG) requires installation of the
+``pylibjpeg`` package as well as the ``pylibjpeg-libjpeg`` and
+``pylibjpeg-openjpeg`` packages. Since ``pylibjpeg-libjpeg`` is licensed under
+a copyleft GPL v3 license, it is not installed by default when you install
+*highdicom*. To install the ``pylibjpeg`` packages along with *highdicom*, use
 
 .. code-block:: none
 

--- a/setup.py
+++ b/setup.py
@@ -55,10 +55,13 @@ setuptools.setup(
         'numpy>=1.19',
         'pillow>=8.3',
         'pillow-jpls>=1.0',
-        'pylibjpeg>=1.4',
         'pylibjpeg-openjpeg>=1.2',
     ],
     extras_requires={
-        'libjpeg': ['pylibjpeg-libjpeg>=1.3'],
+        'libjpeg': [
+            'pylibjpeg>=1.4',
+            'pylibjpeg-libjpeg>=1.3',
+            'pylibjpeg-openjpeg>=1.2'
+        ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setuptools.setup(
         'numpy>=1.19',
         'pillow>=8.3',
         'pillow-jpls>=1.0',
-        'pylibjpeg-openjpeg>=1.2',
     ],
     extras_requires={
         'libjpeg': [

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,9 @@ setuptools.setup(
         'pillow>=8.3',
         'pillow-jpls>=1.0',
         'pylibjpeg>=1.4',
-        'pylibjpeg-libjpeg>=1.3',
         'pylibjpeg-openjpeg>=1.2',
     ],
+    extras_requires={
+        'libjpeg': ['pylibjpeg-libjpeg>=1.3'],
+    },
 )

--- a/src/highdicom/frame.py
+++ b/src/highdicom/frame.py
@@ -258,7 +258,18 @@ def encode_frame(
                 )
 
         elif transfer_syntax_uid == JPEGLSLossless:
-            import pillow_jpls  # noqa
+            try:
+                import pillow_jpls  # noqa
+            except ImportError as e:
+                raise ImportError(
+                    'In order to encode images using the JPEGLSLossless '
+                    'transfer syntax, highdicom requires the '
+                    '"pylibjpeg-libjpeg" package to be installed. This package '
+                    'is not installed by default as it uses a copyleft GPL v3 '
+                    'license. To accept the terms of the GPL v3 license and '
+                    'install highdicom with the "pylibjpeg-libjpeg" package, '
+                    'use "pip install highdicom[libjpeg]".'
+                ) from e
             if samples_per_pixel == 1:
                 if planar_configuration is not None:
                     raise ValueError(

--- a/src/highdicom/frame.py
+++ b/src/highdicom/frame.py
@@ -258,18 +258,7 @@ def encode_frame(
                 )
 
         elif transfer_syntax_uid == JPEGLSLossless:
-            try:
-                import pillow_jpls  # noqa
-            except ImportError as e:
-                raise ImportError(
-                    'In order to encode images using the JPEGLSLossless '
-                    'transfer syntax, highdicom requires the '
-                    '"pylibjpeg-libjpeg" package to be installed. This package '
-                    'is not installed by default as it uses a copyleft GPL v3 '
-                    'license. To accept the terms of the GPL v3 license and '
-                    'install highdicom with the "pylibjpeg-libjpeg" package, '
-                    'use "pip install highdicom[libjpeg]".'
-                ) from e
+            import pillow_jpls  # noqa
             if samples_per_pixel == 1:
                 if planar_configuration is not None:
                     raise ValueError(

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -215,6 +215,7 @@ class TestEncodeFrame(TestCase):
         np.testing.assert_array_equal(frame, decoded_frame)
 
     def test_jpegls_rgb(self):
+        pytest.importorskip("libjpeg")
         bits_allocated = 8
         frame = np.ones((16, 32, 3), dtype=np.dtype(f'uint{bits_allocated}'))
         frame *= 255
@@ -244,6 +245,7 @@ class TestEncodeFrame(TestCase):
         np.testing.assert_array_equal(frame, decoded_frame)
 
     def test_jpegls_monochrome(self):
+        pytest.importorskip("libjpeg")
         bits_allocated = 16
         frame = np.zeros((16, 32), dtype=np.dtype(f'uint{bits_allocated}'))
         compressed_frame = encode_frame(

--- a/tests/test_pm.py
+++ b/tests/test_pm.py
@@ -584,6 +584,7 @@ class TestParametricMap(unittest.TestCase):
         assert np.array_equal(pmap.pixel_array, pixel_array)
 
     def test_multi_frame_sm_image_ushort_encapsulated_jpegls(self):
+        pytest.importorskip("libjpeg")
         pixel_array = np.random.randint(
             low=0,
             high=2**8,

--- a/tests/test_sc.py
+++ b/tests/test_sc.py
@@ -428,6 +428,7 @@ class TestSCImage(unittest.TestCase):
         )
 
     def test_monochrome_jpegls(self):
+        pytest.importorskip("libjpeg")
         bits_allocated = 16
         photometric_interpretation = 'MONOCHROME2'
         coordinate_system = 'PATIENT'
@@ -455,6 +456,7 @@ class TestSCImage(unittest.TestCase):
         )
 
     def test_rgb_jpegls(self):
+        pytest.importorskip("libjpeg")
         bits_allocated = 8
         photometric_interpretation = 'YBR_FULL'
         coordinate_system = 'PATIENT'

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -554,10 +554,10 @@ class TestDimensionIndexSequence(unittest.TestCase):
         assert seq[5].FunctionalGroupPointer == 0x0048021A
 
 
-class TestSegmentation(unittest.TestCase):
+class TestSegmentation:
 
+    @pytest.fixture(autouse=True)
     def setUp(self):
-        super().setUp()
         file_path = Path(__file__)
         data_dir = file_path.parent.parent.joinpath('data')
         self._segmented_property_category = \
@@ -682,6 +682,47 @@ class TestSegmentation(unittest.TestCase):
             dtype=bool
         )
         self._ct_multiframe_mask_array[:, 100:200, 200:400] = True
+
+        self._tests = {
+            'ct-image': ([self._ct_image], self._ct_pixel_array),
+            'sm-image': ([self._sm_image], self._sm_pixel_array),
+            'ct-series': (self._ct_series, self._ct_series_mask_array),
+            'ct-multiframe': (
+                [self._ct_multiframe], self._ct_multiframe_mask_array
+            ),
+        }
+
+    # Fixtures to use to parametrize segmentation creation
+    # Using this fixture mechanism, we can parametrize class methods
+    @staticmethod
+    @pytest.fixture(params=[ExplicitVRLittleEndian, ImplicitVRLittleEndian])
+    def binary_transfer_syntax_uid(request):
+        return request.param
+
+    @staticmethod
+    @pytest.fixture(
+        params=[
+            ExplicitVRLittleEndian,
+            ImplicitVRLittleEndian,
+            RLELossless,
+            JPEG2000Lossless,
+            JPEGLSLossless,
+        ]
+    )
+    def fractional_transfer_syntax_uid(request):
+        return request.param
+
+    @staticmethod
+    @pytest.fixture(params=[np.bool_, np.uint8, np.uint16, np.float_])
+    def pix_type(request):
+        return request.param
+
+    @staticmethod
+    @pytest.fixture(
+        params=['ct-image', 'sm-image', 'ct-series', 'ct-multiframe'],
+    )
+    def test_data(request):
+        return request.param
 
     @staticmethod
     def sort_frames(sources, mask):
@@ -1365,325 +1406,313 @@ class TestSegmentation(unittest.TestCase):
         assert SegmentsOverlapValues[instance.SegmentsOverlap] == \
             SegmentsOverlapValues.NO
 
-    def test_pixel_types(self):
-        # A series of tests on different types of image
-        tests = [
-            ([self._ct_image], self._ct_pixel_array),
-            ([self._sm_image], self._sm_pixel_array),
-            (self._ct_series, self._ct_series_mask_array),
-            ([self._ct_multiframe], self._ct_multiframe_mask_array),
-        ]
+    def test_pixel_types_fractional(
+        self,
+        fractional_transfer_syntax_uid,
+        pix_type,
+        test_data,
+    ):
+        if fractional_transfer_syntax_uid == JPEGLSLossless:
+            pytest.importorskip("libjpeg")
 
-        for sources, mask in tests:
+        sources, mask = self._tests[test_data]
 
-            # Two segments, overlapping
-            multi_segment_overlap = np.stack([mask, mask], axis=-1)
-            if multi_segment_overlap.ndim == 3:
-                multi_segment_overlap = multi_segment_overlap[np.newaxis, ...]
+        # Two segments, overlapping
+        multi_segment_overlap = np.stack([mask, mask], axis=-1)
+        if multi_segment_overlap.ndim == 3:
+            multi_segment_overlap = multi_segment_overlap[np.newaxis, ...]
 
-            # Two segments non-overlapping
-            multi_segment_exc = np.stack([mask, 1 - mask], axis=-1)
-            if multi_segment_exc.ndim == 3:
-                multi_segment_exc = multi_segment_exc[np.newaxis, ...]
-            additional_mask = 1 - mask
+        # Two segments non-overlapping
+        multi_segment_exc = np.stack([mask, 1 - mask], axis=-1)
+        if multi_segment_exc.ndim == 3:
+            multi_segment_exc = multi_segment_exc[np.newaxis, ...]
+        additional_mask = 1 - mask
 
-            # Find the expected encodings for the masks
-            if mask.ndim > 2:
-                # Expected encoding of the mask
-                expected_encoding = self.sort_frames(
-                    sources,
-                    mask
-                )
-                expected_encoding = self.remove_empty_frames(
-                    expected_encoding
-                )
+        # Find the expected encodings for the masks
+        if mask.ndim > 2:
+            # Expected encoding of the mask
+            expected_encoding = self.sort_frames(
+                sources,
+                mask
+            )
+            expected_encoding = self.remove_empty_frames(
+                expected_encoding
+            )
 
-                # Expected encoding of the complement
-                expected_encoding_comp = self.sort_frames(
-                    sources,
-                    additional_mask
-                )
-                expected_encoding_comp = self.remove_empty_frames(
-                    expected_encoding_comp
-                )
+            # Expected encoding of the complement
+            expected_encoding_comp = self.sort_frames(
+                sources,
+                additional_mask
+            )
+            expected_encoding_comp = self.remove_empty_frames(
+                expected_encoding_comp
+            )
 
-                # Expected encoding of the multi segment arrays
-                expected_enc_overlap = np.concatenate(
-                    [expected_encoding, expected_encoding],
-                    axis=0
-                )
-                expected_enc_exc = np.concatenate(
-                    [expected_encoding, expected_encoding_comp],
-                    axis=0
-                )
-                expected_encoding = expected_encoding.squeeze()
-            else:
-                expected_encoding = mask
+            # Expected encoding of the multi segment arrays
+            expected_enc_overlap = np.concatenate(
+                [expected_encoding, expected_encoding],
+                axis=0
+            )
+            expected_enc_exc = np.concatenate(
+                [expected_encoding, expected_encoding_comp],
+                axis=0
+            )
+            expected_encoding = expected_encoding.squeeze()
+        else:
+            expected_encoding = mask
 
-                # Expected encoding of the multi segment arrays
-                expected_enc_overlap = np.stack(
-                    [expected_encoding, expected_encoding],
-                    axis=0
-                )
-                expected_enc_exc = np.stack(
-                    [expected_encoding, 1 - expected_encoding],
-                    axis=0
-                )
+            # Expected encoding of the multi segment arrays
+            expected_enc_overlap = np.stack(
+                [expected_encoding, expected_encoding],
+                axis=0
+            )
+            expected_enc_exc = np.stack(
+                [expected_encoding, 1 - expected_encoding],
+                axis=0
+            )
 
-            # Test instance creation for different pixel types and transfer
-            # syntaxes
-            valid_transfer_syntaxes = [
-                ExplicitVRLittleEndian,
-                ImplicitVRLittleEndian,
-                RLELossless,
-                JPEG2000Lossless,
-                JPEGLSLossless,
-            ]
+        max_fractional_value = 255
+        instance = Segmentation(
+            sources,
+            mask.astype(pix_type),
+            SegmentationTypeValues.FRACTIONAL.value,
+            self._segment_descriptions,
+            self._series_instance_uid,
+            self._series_number,
+            self._sop_instance_uid,
+            self._instance_number,
+            self._manufacturer,
+            self._manufacturer_model_name,
+            self._software_versions,
+            self._device_serial_number,
+            max_fractional_value=max_fractional_value,
+            transfer_syntax_uid=fractional_transfer_syntax_uid
+        )
 
-            max_fractional_value = 255
-            for transfer_syntax_uid in valid_transfer_syntaxes:
-                for pix_type in [np.bool_, np.uint8, np.uint16, np.float_]:
-                    instance = Segmentation(
-                        sources,
-                        mask.astype(pix_type),
-                        SegmentationTypeValues.FRACTIONAL.value,
-                        self._segment_descriptions,
-                        self._series_instance_uid,
-                        self._series_number,
-                        self._sop_instance_uid,
-                        self._instance_number,
-                        self._manufacturer,
-                        self._manufacturer_model_name,
-                        self._software_versions,
-                        self._device_serial_number,
-                        max_fractional_value=max_fractional_value,
-                        transfer_syntax_uid=transfer_syntax_uid
-                    )
+        # Ensure the recovered pixel array matches what is expected
+        if pix_type in (np.bool_, np.float_):
+            assert np.array_equal(
+                self.get_array_after_writing(instance),
+                expected_encoding * max_fractional_value
+            ), f'{sources[0].Modality} {fractional_transfer_syntax_uid}'
+        else:
+            assert np.array_equal(
+                self.get_array_after_writing(instance),
+                expected_encoding
+            ), f'{sources[0].Modality} {fractional_transfer_syntax_uid}'
+        self.check_dimension_index_vals(instance)
 
-                    # Ensure the recovered pixel array matches what is expected
-                    if pix_type in (np.bool_, np.float_):
-                        assert np.array_equal(
-                            self.get_array_after_writing(instance),
-                            expected_encoding * max_fractional_value
-                        ), f'{sources[0].Modality} {transfer_syntax_uid}'
-                    else:
-                        assert np.array_equal(
-                            self.get_array_after_writing(instance),
-                            expected_encoding
-                        ), f'{sources[0].Modality} {transfer_syntax_uid}'
-                    self.check_dimension_index_vals(instance)
+        # Multi-segment (exclusive)
+        instance = Segmentation(
+            sources,
+            multi_segment_exc.astype(pix_type),
+            SegmentationTypeValues.FRACTIONAL.value,
+            self._both_segment_descriptions,
+            self._series_instance_uid,
+            self._series_number,
+            self._sop_instance_uid,
+            self._instance_number,
+            self._manufacturer,
+            self._manufacturer_model_name,
+            self._software_versions,
+            self._device_serial_number,
+            max_fractional_value=1,
+            transfer_syntax_uid=fractional_transfer_syntax_uid
+        )
+        if pix_type == np.float_:
+            assert (
+                instance.SegmentsOverlap ==
+                SegmentsOverlapValues.UNDEFINED.value
+            )
+        else:
+            assert (
+                instance.SegmentsOverlap ==
+                SegmentsOverlapValues.NO.value
+            )
 
-                    # Multi-segment (exclusive)
-                    instance = Segmentation(
-                        sources,
-                        multi_segment_exc.astype(pix_type),
-                        SegmentationTypeValues.FRACTIONAL.value,
-                        self._both_segment_descriptions,
-                        self._series_instance_uid,
-                        self._series_number,
-                        self._sop_instance_uid,
-                        self._instance_number,
-                        self._manufacturer,
-                        self._manufacturer_model_name,
-                        self._software_versions,
-                        self._device_serial_number,
-                        max_fractional_value=1,
-                        transfer_syntax_uid=transfer_syntax_uid
-                    )
-                    if pix_type == np.float_:
-                        assert (
-                            instance.SegmentsOverlap ==
-                            SegmentsOverlapValues.UNDEFINED.value
-                        )
-                    else:
-                        assert (
-                            instance.SegmentsOverlap ==
-                            SegmentsOverlapValues.NO.value
-                        )
+        assert np.array_equal(
+            self.get_array_after_writing(instance),
+            expected_enc_exc
+        ), f'{sources[0].Modality} {fractional_transfer_syntax_uid}'
+        self.check_dimension_index_vals(instance)
 
-                    assert np.array_equal(
-                        self.get_array_after_writing(instance),
-                        expected_enc_exc
-                    ), f'{sources[0].Modality} {transfer_syntax_uid}'
-                    self.check_dimension_index_vals(instance)
+        # Multi-segment (overlapping)
+        instance = Segmentation(
+            sources,
+            multi_segment_overlap.astype(pix_type),
+            SegmentationTypeValues.FRACTIONAL.value,
+            self._both_segment_descriptions,
+            self._series_instance_uid,
+            self._series_number,
+            self._sop_instance_uid,
+            self._instance_number,
+            self._manufacturer,
+            self._manufacturer_model_name,
+            self._software_versions,
+            self._device_serial_number,
+            max_fractional_value=1,
+            transfer_syntax_uid=fractional_transfer_syntax_uid
+        )
+        if pix_type == np.float_:
+            assert (
+                instance.SegmentsOverlap ==
+                SegmentsOverlapValues.UNDEFINED.value
+            )
+        else:
+            assert (
+                instance.SegmentsOverlap ==
+                SegmentsOverlapValues.YES.value
+            )
 
-                    # Multi-segment (overlapping)
-                    instance = Segmentation(
-                        sources,
-                        multi_segment_overlap.astype(pix_type),
-                        SegmentationTypeValues.FRACTIONAL.value,
-                        self._both_segment_descriptions,
-                        self._series_instance_uid,
-                        self._series_number,
-                        self._sop_instance_uid,
-                        self._instance_number,
-                        self._manufacturer,
-                        self._manufacturer_model_name,
-                        self._software_versions,
-                        self._device_serial_number,
-                        max_fractional_value=1,
-                        transfer_syntax_uid=transfer_syntax_uid
-                    )
-                    if pix_type == np.float_:
-                        assert (
-                            instance.SegmentsOverlap ==
-                            SegmentsOverlapValues.UNDEFINED.value
-                        )
-                    else:
-                        assert (
-                            instance.SegmentsOverlap ==
-                            SegmentsOverlapValues.YES.value
-                        )
+        assert np.array_equal(
+            self.get_array_after_writing(instance),
+            expected_enc_overlap
+        ), f'{sources[0].Modality} {fractional_transfer_syntax_uid}'
+        self.check_dimension_index_vals(instance)
 
-                    assert np.array_equal(
-                        self.get_array_after_writing(instance),
-                        expected_enc_overlap
-                    ), f'{sources[0].Modality} {transfer_syntax_uid}'
-                    self.check_dimension_index_vals(instance)
+    def test_pixel_types_binary(
+        self,
+        binary_transfer_syntax_uid,
+        pix_type,
+        test_data,
+    ):
+        sources, mask = self._tests[test_data]
 
-        for sources, mask in tests:
-            # Two segments, overlapping
-            multi_segment_overlap = np.stack([mask, mask], axis=-1)
-            if multi_segment_overlap.ndim == 3:
-                multi_segment_overlap = multi_segment_overlap[np.newaxis, ...]
+        # Two segments, overlapping
+        multi_segment_overlap = np.stack([mask, mask], axis=-1)
+        if multi_segment_overlap.ndim == 3:
+            multi_segment_overlap = multi_segment_overlap[np.newaxis, ...]
 
-            # Two segments non-overlapping
-            multi_segment_exc = np.stack([mask, 1 - mask], axis=-1)
+        # Two segments non-overlapping
+        multi_segment_exc = np.stack([mask, 1 - mask], axis=-1)
 
-            if multi_segment_exc.ndim == 3:
-                multi_segment_exc = multi_segment_exc[np.newaxis, ...]
-            additional_mask = 1 - mask
+        if multi_segment_exc.ndim == 3:
+            multi_segment_exc = multi_segment_exc[np.newaxis, ...]
+        additional_mask = 1 - mask
 
-            additional_mask = (1 - mask)
-            # Find the expected encodings for the masks
-            if mask.ndim > 2:
-                # Expected encoding of the mask
-                expected_encoding = self.sort_frames(
-                    sources,
-                    mask
-                )
-                expected_encoding = self.remove_empty_frames(
-                    expected_encoding
-                )
+        additional_mask = (1 - mask)
+        # Find the expected encodings for the masks
+        if mask.ndim > 2:
+            # Expected encoding of the mask
+            expected_encoding = self.sort_frames(
+                sources,
+                mask
+            )
+            expected_encoding = self.remove_empty_frames(
+                expected_encoding
+            )
 
-                # Expected encoding of the complement
-                expected_encoding_comp = self.sort_frames(
-                    sources,
-                    additional_mask
-                )
-                expected_encoding_comp = self.remove_empty_frames(
-                    expected_encoding_comp
-                )
+            # Expected encoding of the complement
+            expected_encoding_comp = self.sort_frames(
+                sources,
+                additional_mask
+            )
+            expected_encoding_comp = self.remove_empty_frames(
+                expected_encoding_comp
+            )
 
-                # Expected encoding of the multi segment arrays
-                expected_enc_overlap = np.concatenate(
-                    [expected_encoding, expected_encoding],
-                    axis=0
-                )
-                expected_enc_exc = np.concatenate(
-                    [expected_encoding, expected_encoding_comp],
-                    axis=0
-                )
-                expected_encoding = expected_encoding.squeeze()
-            else:
-                expected_encoding = mask
+            # Expected encoding of the multi segment arrays
+            expected_enc_overlap = np.concatenate(
+                [expected_encoding, expected_encoding],
+                axis=0
+            )
+            expected_enc_exc = np.concatenate(
+                [expected_encoding, expected_encoding_comp],
+                axis=0
+            )
+            expected_encoding = expected_encoding.squeeze()
+        else:
+            expected_encoding = mask
 
-                # Expected encoding of the multi segment arrays
-                expected_enc_overlap = np.stack(
-                    [expected_encoding, expected_encoding],
-                    axis=0
-                )
-                expected_enc_exc = np.stack(
-                    [expected_encoding, 1 - expected_encoding],
-                    axis=0
-                )
+            # Expected encoding of the multi segment arrays
+            expected_enc_overlap = np.stack(
+                [expected_encoding, expected_encoding],
+                axis=0
+            )
+            expected_enc_exc = np.stack(
+                [expected_encoding, 1 - expected_encoding],
+                axis=0
+            )
 
-            valid_transfer_syntaxes = [
-                ExplicitVRLittleEndian,
-                ImplicitVRLittleEndian,
-            ]
+        instance = Segmentation(
+            sources,
+            mask.astype(pix_type),
+            SegmentationTypeValues.BINARY.value,
+            self._segment_descriptions,
+            self._series_instance_uid,
+            self._series_number,
+            self._sop_instance_uid,
+            self._instance_number,
+            self._manufacturer,
+            self._manufacturer_model_name,
+            self._software_versions,
+            self._device_serial_number,
+            max_fractional_value=1,
+            transfer_syntax_uid=binary_transfer_syntax_uid
+        )
 
-            for transfer_syntax_uid in valid_transfer_syntaxes:
-                for pix_type in [np.bool_, np.uint8, np.uint16, np.float_]:
-                    instance = Segmentation(
-                        sources,
-                        mask.astype(pix_type),
-                        SegmentationTypeValues.BINARY.value,
-                        self._segment_descriptions,
-                        self._series_instance_uid,
-                        self._series_number,
-                        self._sop_instance_uid,
-                        self._instance_number,
-                        self._manufacturer,
-                        self._manufacturer_model_name,
-                        self._software_versions,
-                        self._device_serial_number,
-                        max_fractional_value=1,
-                        transfer_syntax_uid=transfer_syntax_uid
-                    )
+        # Ensure the recovered pixel array matches what is expected
+        assert np.array_equal(
+            self.get_array_after_writing(instance),
+            expected_encoding
+        ), f'{sources[0].Modality} {binary_transfer_syntax_uid}'
+        self.check_dimension_index_vals(instance)
 
-                    # Ensure the recovered pixel array matches what is expected
-                    assert np.array_equal(
-                        self.get_array_after_writing(instance),
-                        expected_encoding
-                    ), f'{sources[0].Modality} {transfer_syntax_uid}'
-                    self.check_dimension_index_vals(instance)
+        # Multi-segment (exclusive)
+        instance = Segmentation(
+            sources,
+            multi_segment_exc.astype(pix_type),
+            SegmentationTypeValues.BINARY.value,
+            self._both_segment_descriptions,
+            self._series_instance_uid,
+            self._series_number,
+            self._sop_instance_uid,
+            self._instance_number,
+            self._manufacturer,
+            self._manufacturer_model_name,
+            self._software_versions,
+            self._device_serial_number,
+            max_fractional_value=1,
+            transfer_syntax_uid=binary_transfer_syntax_uid
+        )
+        assert (
+            instance.SegmentsOverlap ==
+            SegmentsOverlapValues.NO.value
+        )
 
-                    # Multi-segment (exclusive)
-                    instance = Segmentation(
-                        sources,
-                        multi_segment_exc.astype(pix_type),
-                        SegmentationTypeValues.BINARY.value,
-                        self._both_segment_descriptions,
-                        self._series_instance_uid,
-                        self._series_number,
-                        self._sop_instance_uid,
-                        self._instance_number,
-                        self._manufacturer,
-                        self._manufacturer_model_name,
-                        self._software_versions,
-                        self._device_serial_number,
-                        max_fractional_value=1,
-                        transfer_syntax_uid=transfer_syntax_uid
-                    )
-                    assert (
-                        instance.SegmentsOverlap ==
-                        SegmentsOverlapValues.NO.value
-                    )
+        assert np.array_equal(
+            self.get_array_after_writing(instance),
+            expected_enc_exc
+        ), f'{sources[0].Modality} {binary_transfer_syntax_uid}'
+        self.check_dimension_index_vals(instance)
 
-                    assert np.array_equal(
-                        self.get_array_after_writing(instance),
-                        expected_enc_exc
-                    ), f'{sources[0].Modality} {transfer_syntax_uid}'
-                    self.check_dimension_index_vals(instance)
+        # Multi-segment (overlapping)
+        instance = Segmentation(
+            sources,
+            multi_segment_overlap.astype(pix_type),
+            SegmentationTypeValues.BINARY.value,
+            self._both_segment_descriptions,
+            self._series_instance_uid,
+            self._series_number,
+            self._sop_instance_uid,
+            self._instance_number,
+            self._manufacturer,
+            self._manufacturer_model_name,
+            self._software_versions,
+            self._device_serial_number,
+            max_fractional_value=1,
+            transfer_syntax_uid=binary_transfer_syntax_uid
+        )
+        assert (
+            instance.SegmentsOverlap ==
+            SegmentsOverlapValues.YES.value
+        )
 
-                    # Multi-segment (overlapping)
-                    instance = Segmentation(
-                        sources,
-                        multi_segment_overlap.astype(pix_type),
-                        SegmentationTypeValues.BINARY.value,
-                        self._both_segment_descriptions,
-                        self._series_instance_uid,
-                        self._series_number,
-                        self._sop_instance_uid,
-                        self._instance_number,
-                        self._manufacturer,
-                        self._manufacturer_model_name,
-                        self._software_versions,
-                        self._device_serial_number,
-                        max_fractional_value=1,
-                        transfer_syntax_uid=transfer_syntax_uid
-                    )
-                    assert (
-                        instance.SegmentsOverlap ==
-                        SegmentsOverlapValues.YES.value
-                    )
-
-                    assert np.array_equal(
-                        self.get_array_after_writing(instance),
-                        expected_enc_overlap
-                    ), f'{sources[0].Modality} {transfer_syntax_uid}'
-                    self.check_dimension_index_vals(instance)
+        assert np.array_equal(
+            self.get_array_after_writing(instance),
+            expected_enc_overlap
+        ), f'{sources[0].Modality} {binary_transfer_syntax_uid}'
+        self.check_dimension_index_vals(instance)
 
     def test_odd_number_pixels(self):
         # Test that an image with an odd number of pixels per frame is encoded


### PR DESCRIPTION
Highdicom is licensed under the permissive MIT license to allow users to use in their own applications, regardless of licence.

Unfortunately, it currently depends on `pylibjpeg-libjpeg`, which is GPL v3 licensed. This effectively means that many users cannot use highdicom. Luckily highdicom only uses `pylibjpeg-libjpeg` indirectly through pydicom and only in a few specific cases (decoding pixel data with a few specific transfer syntaxes).

This PR moves `pylibjpeg-libjpeg` to an optional dependency, that users may install with `pip install highdicom[libjpeg]`, and adds documentation to this effect.

It also alters the tests so that the relevant tests are automatically skipped if `pylibjpeg-libjpeg` is not installed. This necessitated a (long overdue) restructuring of the segmentation tests to split for loops within a single test to parameterized tests (using fixtures). 