### PR TITLE
Optionally skip deepcopy in `from_dataset` methods

### DIFF
--- a/src/highdicom/content.py
+++ b/src/highdicom/content.py
@@ -93,7 +93,8 @@ class AlgorithmIdentificationSequence(DataElementSequence):
     @classmethod
     def from_sequence(
         cls,
-        sequence: DataElementSequence
+        sequence: DataElementSequence,
+        copy: bool = True,
     ) -> 'AlgorithmIdentificationSequence':
         """Construct instance from an existing data element sequence.
 
@@ -102,6 +103,10 @@ class AlgorithmIdentificationSequence(DataElementSequence):
         sequence: pydicom.sequence.Sequence
             Data element sequence representing the
             Algorithm Identification Sequence
+        copy: bool
+            If True, the underlying sequence is deep-copied such that the
+            original sequence remains intact. If False, this operation will
+            alter the original sequence in place.
 
         Returns
         -------
@@ -123,7 +128,10 @@ class AlgorithmIdentificationSequence(DataElementSequence):
                 'SegmentationAlgorithmIdentificationSequence'
             ]
         )
-        algo_id_sequence = deepcopy(sequence)
+        if copy:
+            algo_id_sequence = deepcopy(sequence)
+        else:
+            algo_id_sequence = sequence
         algo_id_sequence.__class__ = AlgorithmIdentificationSequence
         return cast(AlgorithmIdentificationSequence, algo_id_sequence)
 
@@ -331,7 +339,8 @@ class PixelMeasuresSequence(DataElementSequence):
     @classmethod
     def from_sequence(
         cls,
-        sequence: DataElementSequence
+        sequence: DataElementSequence,
+        copy: bool = True,
     ) -> 'PixelMeasuresSequence':
         """Create a PixelMeasuresSequence from an existing Sequence.
 
@@ -339,6 +348,10 @@ class PixelMeasuresSequence(DataElementSequence):
         ----------
         sequence: pydicom.sequence.Sequence
             Sequence to be converted.
+        copy: bool
+            If True, the underlying sequence is deep-copied such that the
+            original sequence remains intact. If False, this operation will
+            alter the original sequence in place.
 
         Returns
         -------
@@ -369,7 +382,10 @@ class PixelMeasuresSequence(DataElementSequence):
                 'a Pixel Measures Sequence.'
             )
 
-        pixel_measures = deepcopy(sequence)
+        if copy:
+            pixel_measures = deepcopy(sequence)
+        else:
+            pixel_measures = sequence
         pixel_measures.__class__ = PixelMeasuresSequence
         return cast(PixelMeasuresSequence, pixel_measures)
 
@@ -480,7 +496,8 @@ class PlanePositionSequence(DataElementSequence):
     @classmethod
     def from_sequence(
         cls,
-        sequence: DataElementSequence
+        sequence: DataElementSequence,
+        copy: bool = True,
     ) -> 'PlanePositionSequence':
         """Create a PlanePositionSequence from an existing Sequence.
 
@@ -490,6 +507,10 @@ class PlanePositionSequence(DataElementSequence):
         ----------
         sequence: pydicom.sequence.Sequence
             Sequence to be converted.
+        copy: bool
+            If True, the underlying sequence is deep-copied such that the
+            original sequence remains intact. If False, this operation will
+            alter the original sequence in place.
 
         Returns
         -------
@@ -523,7 +544,10 @@ class PlanePositionSequence(DataElementSequence):
                 ]
             )
 
-        plane_position = deepcopy(sequence)
+        if copy:
+            plane_position = deepcopy(sequence)
+        else:
+            plane_position = sequence
         plane_position.__class__ = PlanePositionSequence
         return cast(PlanePositionSequence, plane_position)
 
@@ -612,7 +636,8 @@ class PlaneOrientationSequence(DataElementSequence):
     @classmethod
     def from_sequence(
         cls,
-        sequence: DataElementSequence
+        sequence: DataElementSequence,
+        copy: bool = True,
     ) -> 'PlaneOrientationSequence':
         """Create a PlaneOrientationSequence from an existing Sequence.
 
@@ -622,6 +647,10 @@ class PlaneOrientationSequence(DataElementSequence):
         ----------
         sequence: pydicom.sequence.Sequence
             Sequence to be converted.
+        copy: bool
+            If True, the underlying sequence is deep-copied such that the
+            original sequence remains intact. If False, this operation will
+            alter the original sequence in place.
 
         Returns
         -------
@@ -652,7 +681,10 @@ class PlaneOrientationSequence(DataElementSequence):
                     'either the PATIENT or SLIDE coordinate system.'
                 )
 
-        plane_orientation = deepcopy(sequence)
+        if copy:
+            plane_orientation = deepcopy(sequence)
+        else:
+            plane_orientation = sequence
         plane_orientation.__class__ = PlaneOrientationSequence
         return cast(PlaneOrientationSequence, plane_orientation)
 

--- a/src/highdicom/seg/content.py
+++ b/src/highdicom/seg/content.py
@@ -138,13 +138,21 @@ class SegmentDescription(Dataset):
             ]
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'SegmentDescription':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True
+    ) -> 'SegmentDescription':
         """Construct instance from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an item of the Segment Sequence.
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -161,33 +169,39 @@ class SegmentDescription(Dataset):
             module='segmentation-image',
             base_path=['SegmentSequence']
         )
-        desc = deepcopy(dataset)
+        if copy:
+            desc = deepcopy(dataset)
+        else:
+            desc = dataset
         desc.__class__ = cls
 
         # Convert sub sequences to highdicom types
         desc.SegmentedPropertyCategoryCodeSequence = [
             CodedConcept.from_dataset(
-                desc.SegmentedPropertyCategoryCodeSequence[0]
+                desc.SegmentedPropertyCategoryCodeSequence[0],
+                copy=False,
             )
         ]
         desc.SegmentedPropertyTypeCodeSequence = [
             CodedConcept.from_dataset(
-                desc.SegmentedPropertyTypeCodeSequence[0]
+                desc.SegmentedPropertyTypeCodeSequence[0],
+                copy=False,
             )
         ]
         if hasattr(desc, 'SegmentationAlgorithmIdentificationSequence'):
             desc.SegmentationAlgorithmIdentificationSequence = \
                 AlgorithmIdentificationSequence.from_sequence(
-                    desc.SegmentationAlgorithmIdentificationSequence
+                    desc.SegmentationAlgorithmIdentificationSequence,
+                    copy=False,
                 )
         if hasattr(desc, 'AnatomicRegionSequence'):
             desc.AnatomicRegionSequence = [
-                CodedConcept.from_dataset(ds)
+                CodedConcept.from_dataset(ds, copy=False)
                 for ds in desc.AnatomicRegionSequence
             ]
         if hasattr(desc, 'PrimaryAnatomicStructureSequence'):
             desc.PrimaryAnatomicStructureSequence = [
-                CodedConcept.from_dataset(ds)
+                CodedConcept.from_dataset(ds, copy=False)
                 for ds in desc.PrimaryAnatomicStructureSequence
             ]
         return cast(SegmentDescription, desc)

--- a/src/highdicom/sr/coding.py
+++ b/src/highdicom/sr/coding.py
@@ -92,13 +92,21 @@ class CodedConcept(Dataset):
         return not (self == other)
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'CodedConcept':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True
+    ) -> 'CodedConcept':
         """Construct a CodedConcept from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing a coded concept.
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -124,7 +132,10 @@ class CodedConcept(Dataset):
                     'Dataset does not contain the following attribute '
                     f'required for coded concepts: {kw}.'
                 )
-        concept = deepcopy(dataset)
+        if copy:
+            concept = deepcopy(dataset)
+        else:
+            concept = dataset
         concept.__class__ = cls
         return concept
 

--- a/src/highdicom/sr/content.py
+++ b/src/highdicom/sr/content.py
@@ -155,7 +155,8 @@ class LongitudinalTemporalOffsetFromEvent(NumContentItem):
     @classmethod
     def from_dataset(
         cls,
-        dataset: Dataset
+        dataset: Dataset,
+        copy: bool = True,
     ) -> 'LongitudinalTemporalOffsetFromEvent':
         """Construct object from an existing dataset.
 
@@ -163,6 +164,10 @@ class LongitudinalTemporalOffsetFromEvent(NumContentItem):
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type SCOORD
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -170,15 +175,11 @@ class LongitudinalTemporalOffsetFromEvent(NumContentItem):
             Constructed object
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(
-        cls,
-        dataset: Dataset
-    ) -> 'LongitudinalTemporalOffsetFromEvent':
-        item = super()._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        item = super()._from_dataset_base(dataset_copy)
         return cast(LongitudinalTemporalOffsetFromEvent, item)
 
 
@@ -264,13 +265,21 @@ class SourceImageForMeasurementGroup(ImageContentItem):
         )
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'SourceImageForMeasurementGroup':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'SourceImageForMeasurementGroup':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type IMAGE
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -278,15 +287,11 @@ class SourceImageForMeasurementGroup(ImageContentItem):
             Constructed object
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(
-        cls,
-        dataset: Dataset
-    ) -> 'SourceImageForMeasurementGroup':
-        item = super()._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        item = super()._from_dataset_base(dataset_copy)
         return cast(SourceImageForMeasurementGroup, item)
 
 
@@ -372,13 +377,21 @@ class SourceImageForMeasurement(ImageContentItem):
         )
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'SourceImageForMeasurement':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'SourceImageForMeasurement':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type IMAGE
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -386,12 +399,11 @@ class SourceImageForMeasurement(ImageContentItem):
             Constructed object
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'SourceImageForMeasurement':
-        item = super()._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        item = super()._from_dataset_base(dataset_copy)
         return cast(SourceImageForMeasurement, item)
 
 
@@ -477,13 +489,21 @@ class SourceImageForRegion(ImageContentItem):
         )
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'SourceImageForRegion':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'SourceImageForRegion':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type SCOORD
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -492,11 +512,7 @@ class SourceImageForRegion(ImageContentItem):
 
         """
         dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'SourceImageForRegion':
-        item = super()._from_dataset_base(dataset)
+        item = super()._from_dataset_base(dataset_copy)
         return cast(SourceImageForRegion, item)
 
 
@@ -582,13 +598,21 @@ class SourceImageForSegmentation(ImageContentItem):
         )
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'SourceImageForSegmentation':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'SourceImageForSegmentation':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type SCOORD
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -596,12 +620,11 @@ class SourceImageForSegmentation(ImageContentItem):
             Constructed object
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'SourceImageForSegmentation':
-        item = super()._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        item = super()._from_dataset_base(dataset_copy)
         return cast(SourceImageForSegmentation, item)
 
 
@@ -654,13 +677,21 @@ class SourceSeriesForSegmentation(UIDRefContentItem):
         )
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'SourceSeriesForSegmentation':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'SourceSeriesForSegmentation':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type SCOORD
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -668,12 +699,11 @@ class SourceSeriesForSegmentation(UIDRefContentItem):
             Constructed object
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'SourceSeriesForSegmentation':
-        item = super()._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        item = super()._from_dataset_base(dataset_copy)
         return cast(SourceSeriesForSegmentation, item)
 
 
@@ -748,13 +778,21 @@ class ImageRegion(ScoordContentItem):
         self.ContentSequence = [source_image]
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'ImageRegion':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'ImageRegion':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type SCOORD
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -762,12 +800,11 @@ class ImageRegion(ScoordContentItem):
             Constructed object
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'ImageRegion':
-        item = super()._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        item = super()._from_dataset_base(dataset_copy)
         return cast(ImageRegion, item)
 
 
@@ -817,13 +854,21 @@ class ImageRegion3D(Scoord3DContentItem):
         )
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'ImageRegion3D':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'ImageRegion3D':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type SCOORD
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -831,12 +876,11 @@ class ImageRegion3D(Scoord3DContentItem):
             Constructed object
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'ImageRegion3D':
-        item = super()._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        item = super()._from_dataset_base(dataset_copy)
         return cast(ImageRegion3D, item)
 
 
@@ -1198,13 +1242,21 @@ class RealWorldValueMap(CompositeContentItem):
         )
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'RealWorldValueMap':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'RealWorldValueMap':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type SCOORD
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -1212,12 +1264,11 @@ class RealWorldValueMap(CompositeContentItem):
             Constructed object
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'RealWorldValueMap':
-        item = super()._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        item = super()._from_dataset_base(dataset_copy)
         return cast(RealWorldValueMap, item)
 
 
@@ -1315,13 +1366,21 @@ class FindingSite(CodeContentItem):
         return None
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'FindingSite':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'FindingSite':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type SCOORD
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -1329,12 +1388,11 @@ class FindingSite(CodeContentItem):
             Constructed object
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'FindingSite':
-        item = super()._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        item = super()._from_dataset_base(dataset_copy)
         return cast(FindingSite, item)
 
 

--- a/src/highdicom/sr/sop.py
+++ b/src/highdicom/sr/sop.py
@@ -268,13 +268,17 @@ class _SR(SOPClass):
         return _create_references(group)
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> Dataset:
+    def from_dataset(cls, dataset: Dataset, copy: bool = True) -> Dataset:
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing a Comprehensive SR document
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -285,7 +289,10 @@ class _SR(SOPClass):
         if not hasattr(dataset, 'ContentSequence'):
             raise ValueError('Dataset is not an SR document.')
         _check_little_endian(dataset)
-        sop_instance = deepcopy(dataset)
+        if copy:
+            sop_instance = deepcopy(dataset)
+        else:
+            sop_instance = dataset
         sop_instance.__class__ = cls
 
         root_item = Dataset()
@@ -298,15 +305,20 @@ class _SR(SOPClass):
             tid_item = dataset.ContentTemplateSequence[0]
             if tid_item.TemplateIdentifier == '1500':
                 sop_instance._content = MeasurementReport.from_sequence(
-                    [root_item]
+                    [root_item],
+                    copy=False,
                 )
             else:
                 sop_instance._content = ContentSequence.from_sequence(
-                    [root_item], is_root=True
+                    [root_item],
+                    is_root=True,
+                    copy=False,
                 )
         except AttributeError:
             sop_instance._content = ContentSequence.from_sequence(
-                [root_item], is_root=True
+                [root_item],
+                is_root=True,
+                copy=False,
             )
 
         return sop_instance
@@ -581,13 +593,21 @@ class ComprehensiveSR(_SR):
             )
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'ComprehensiveSR':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'ComprehensiveSR':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing a Comprehensive SR document
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -597,7 +617,7 @@ class ComprehensiveSR(_SR):
         """
         if dataset.SOPClassUID != ComprehensiveSRStorage:
             raise ValueError('Dataset is not a Comprehensive SR document.')
-        sop_instance = super().from_dataset(dataset)
+        sop_instance = super().from_dataset(dataset, copy=copy)
         sop_instance.__class__ = ComprehensiveSR
         return cast(ComprehensiveSR, sop_instance)
 
@@ -723,13 +743,21 @@ class Comprehensive3DSR(_SR):
         )
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'Comprehensive3DSR':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True
+    ) -> 'Comprehensive3DSR':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing a Comprehensive 3D SR document
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -739,6 +767,6 @@ class Comprehensive3DSR(_SR):
         """
         if dataset.SOPClassUID != Comprehensive3DSRStorage:
             raise ValueError('Dataset is not a Comprehensive 3D SR document.')
-        sop_instance = super().from_dataset(dataset)
+        sop_instance = super().from_dataset(dataset, copy=copy)
         sop_instance.__class__ = Comprehensive3DSR
         return cast(Comprehensive3DSR, sop_instance)

--- a/src/highdicom/sr/templates.py
+++ b/src/highdicom/sr/templates.py
@@ -4189,7 +4189,8 @@ class MeasurementReport(Template):
     def from_sequence(
         cls,
         sequence: Sequence[Dataset],
-        is_root: bool = True
+        is_root: bool = True,
+        copy: bool = True,
     ) -> 'MeasurementReport':
         """Construct object from a sequence of datasets.
 
@@ -4202,6 +4203,10 @@ class MeasurementReport(Template):
             Whether the sequence is used to contain SR Content Items that are
             intended to be added to an SR document at the root of the document
             content tree
+        copy: bool
+            If True, the underlying sequence is deep-copied such that the
+            original sequence remains intact. If False, this operation will
+            alter the original sequence in place.
 
         Returns
         -------
@@ -4226,7 +4231,11 @@ class MeasurementReport(Template):
                 'Item #1 of sequence is not an appropriate SR Content Item '
                 'because it does not have Template Identifier "1500".'
             )
-        instance = ContentSequence.from_sequence(sequence, is_root=True)
+        instance = ContentSequence.from_sequence(
+            sequence,
+            is_root=True,
+            copy=copy
+        )
         instance.__class__ = MeasurementReport
         return cast(MeasurementReport, instance)
 

--- a/src/highdicom/sr/value_types.py
+++ b/src/highdicom/sr/value_types.py
@@ -177,7 +177,10 @@ class ContentItem(Dataset):
         """
         value_type = ValueTypeValues(dataset.ValueType)
         content_item_cls = _get_content_item_class(value_type)
-        return content_item_cls.from_dataset(dataset, copy=False)  # type: ignore
+        return content_item_cls.from_dataset(
+            dataset,
+            copy=False
+        )  # type: ignore
 
     @classmethod
     def _from_dataset_base(cls, dataset: Dataset) -> 'ContentItem':

--- a/src/highdicom/sr/value_types.py
+++ b/src/highdicom/sr/value_types.py
@@ -177,7 +177,7 @@ class ContentItem(Dataset):
         """
         value_type = ValueTypeValues(dataset.ValueType)
         content_item_cls = _get_content_item_class(value_type)
-        return content_item_cls._from_dataset(dataset)  # type: ignore
+        return content_item_cls.from_dataset(dataset, copy=False)  # type: ignore
 
     @classmethod
     def _from_dataset_base(cls, dataset: Dataset) -> 'ContentItem':
@@ -212,11 +212,15 @@ class ContentItem(Dataset):
         item = dataset
         item.__class__ = cls
         if hasattr(item, 'ContentSequence'):
-            item.ContentSequence = ContentSequence._from_sequence(
-                item.ContentSequence
+            item.ContentSequence = ContentSequence.from_sequence(
+                item.ContentSequence,
+                copy=False
             )
         item.ConceptNameCodeSequence = [
-            CodedConcept.from_dataset(item.ConceptNameCodeSequence[0])
+            CodedConcept.from_dataset(
+                item.ConceptNameCodeSequence[0],
+                copy=False
+            )
         ]
         return cast(ContentItem, item)
 
@@ -550,7 +554,8 @@ class ContentSequence(DataElementSequence):
         cls,
         sequence: Sequence[Dataset],
         is_root: bool = False,
-        is_sr: bool = True
+        is_sr: bool = True,
+        copy: bool = True,
     ) -> 'ContentSequence':
         """Construct object from a sequence of datasets.
 
@@ -567,6 +572,10 @@ class ContentSequence(DataElementSequence):
             intended to be added to an SR document as opposed to other types
             of IODs based on an acquisition, protocol or workflow context
             template
+        copy: bool
+            If True, the underlying sequence is deep-copied such that the
+            original sequence remains intact. If False, this operation will
+            alter the original sequence in place.
 
         Returns
         -------
@@ -582,49 +591,11 @@ class ContentSequence(DataElementSequence):
                 is_sr=is_sr,
                 index=i
             )
-            dataset_copy = deepcopy(dataset)
+            if copy:
+                dataset_copy = deepcopy(dataset)
+            else:
+                dataset_copy = dataset
             item = ContentItem._from_dataset_derived(dataset_copy)
-            content_items.append(item)
-        return ContentSequence(content_items, is_root=is_root, is_sr=is_sr)
-
-    @classmethod
-    def _from_sequence(
-        cls,
-        sequence: Sequence[Dataset],
-        is_root: bool = False,
-        is_sr: bool = True
-    ) -> 'ContentSequence':
-        """Construct object from a sequence of datasets.
-
-        Parameters
-        ----------
-        sequence: Sequence[pydicom.dataset.Dataset]
-            Datasets representing SR Content Items
-        is_root: bool, optional
-            Whether the sequence is used to contain SR Content Items that are
-            intended to be added to an SR document at the root of the document
-            content tree
-        is_sr: bool, optional
-            Whether the sequence is use to contain SR Content Items that are
-            intended to be added to an SR document as opposed to other types
-            of IODs based on an acquisition, protocol or workflow context
-            template
-
-        Returns
-        -------
-        highdicom.sr.ContentSequence
-            Content Sequence containing SR Content Items
-
-        """
-        content_items = []
-        for i, dataset in enumerate(sequence, 1):
-            cls._check_dataset(
-                dataset,
-                is_root=is_root,
-                is_sr=is_sr,
-                index=i
-            )
-            item = ContentItem._from_dataset_derived(dataset)
             content_items.append(item)
         return ContentSequence(content_items, is_root=is_root, is_sr=is_sr)
 
@@ -713,13 +684,21 @@ class CodeContentItem(ContentItem):
         return self.ConceptCodeSequence[0]
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'CodeContentItem':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'CodeContentItem':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type CODE
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -727,32 +706,14 @@ class CodeContentItem(ContentItem):
             Content Item
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'CodeContentItem':
-        """Construct object from an existing dataset.
-
-        Parameters
-        ----------
-        dataset: pydicom.dataset.Dataset
-            Dataset representing an SR Content Item with value type CODE
-
-        Returns
-        -------
-        highdicom.sr.CodeContentItem
-            Content Item
-
-        Note
-        ----
-        Does not create a copy, but modifies `dataset`.
-
-        """
-        _assert_value_type(dataset, ValueTypeValues.CODE)
-        item = super(CodeContentItem, cls)._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        _assert_value_type(dataset_copy, ValueTypeValues.CODE)
+        item = super(CodeContentItem, cls)._from_dataset_base(dataset_copy)
         item.ConceptCodeSequence = DataElementSequence([
-            CodedConcept.from_dataset(item.ConceptCodeSequence[0])
+            CodedConcept.from_dataset(item.ConceptCodeSequence[0], copy=False)
         ])
         return cast(CodeContentItem, item)
 
@@ -790,13 +751,21 @@ class PnameContentItem(ContentItem):
         return PersonName(self.PersonName)
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'PnameContentItem':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'PnameContentItem':
         """Construct object from existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type PNAME
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -804,30 +773,12 @@ class PnameContentItem(ContentItem):
             Content Item
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'PnameContentItem':
-        """Construct object from existing dataset.
-
-        Parameters
-        ----------
-        dataset: pydicom.dataset.Dataset
-            Dataset representing an SR Content Item with value type PNAME
-
-        Returns
-        -------
-        highdicom.sr.PnameContentItem
-            Content Item
-
-        Note
-        ----
-        Does not create a copy, but modifies `dataset`.
-
-        """
-        _assert_value_type(dataset, ValueTypeValues.PNAME)
-        item = super(PnameContentItem, cls)._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        _assert_value_type(dataset_copy, ValueTypeValues.PNAME)
+        item = super(PnameContentItem, cls)._from_dataset_base(dataset_copy)
         return cast(PnameContentItem, item)
 
 
@@ -863,13 +814,21 @@ class TextContentItem(ContentItem):
         return self.TextValue
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'TextContentItem':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'TextContentItem':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type TEXT
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -877,30 +836,12 @@ class TextContentItem(ContentItem):
             Content Item
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'TextContentItem':
-        """Construct object from an existing dataset.
-
-        Parameters
-        ----------
-        dataset: pydicom.dataset.Dataset
-            Dataset representing an SR Content Item with value type TEXT
-
-        Returns
-        -------
-        highdicom.sr.TextContentItem
-            Content Item
-
-        Note
-        ----
-        Does not create a copy, but modifies `dataset`.
-
-        """
-        _assert_value_type(dataset, ValueTypeValues.TEXT)
-        item = super(TextContentItem, cls)._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        _assert_value_type(dataset_copy, ValueTypeValues.TEXT)
+        item = super(TextContentItem, cls)._from_dataset_base(dataset_copy)
         return cast(TextContentItem, item)
 
 
@@ -948,13 +889,21 @@ class TimeContentItem(ContentItem):
         raise ValueError(f'Could not decode time value "{self.Time}"')
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'TimeContentItem':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'TimeContentItem':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type TIME
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -962,30 +911,12 @@ class TimeContentItem(ContentItem):
             Content Item
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'TimeContentItem':
-        """Construct object from an existing dataset.
-
-        Parameters
-        ----------
-        dataset: pydicom.dataset.Dataset
-            Dataset representing an SR Content Item with value type TIME
-
-        Returns
-        -------
-        highdicom.sr.TimeContentItem
-            Content Item
-
-        Note
-        ----
-        Does not create a copy, but modifies `dataset`.
-
-        """
-        _assert_value_type(dataset, ValueTypeValues.TIME)
-        item = super(TimeContentItem, cls)._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        _assert_value_type(dataset_copy, ValueTypeValues.TIME)
+        item = super(TimeContentItem, cls)._from_dataset_base(dataset_copy)
         return cast(TimeContentItem, item)
 
 
@@ -1022,13 +953,21 @@ class DateContentItem(ContentItem):
         return datetime.datetime.strptime(self.Date.isoformat(), fmt).date()
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'DateContentItem':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'DateContentItem':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type DATE
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -1036,30 +975,12 @@ class DateContentItem(ContentItem):
             Content Item
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'DateContentItem':
-        """Construct object from an existing dataset.
-
-        Parameters
-        ----------
-        dataset: pydicom.dataset.Dataset
-            Dataset representing an SR Content Item with value type DATE
-
-        Returns
-        -------
-        highdicom.sr.DateContentItem
-            Content Item
-
-        Note
-        ----
-        Does not create a copy, but modifies `dataset`.
-
-        """
-        _assert_value_type(dataset, ValueTypeValues.DATE)
-        item = super(DateContentItem, cls)._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        _assert_value_type(dataset_copy, ValueTypeValues.DATE)
+        item = super(DateContentItem, cls)._from_dataset_base(dataset_copy)
         return cast(DateContentItem, item)
 
 
@@ -1114,13 +1035,21 @@ class DateTimeContentItem(ContentItem):
         raise ValueError(f'Could not decode datetime value "{self.DateTime}"')
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'DateTimeContentItem':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'DateTimeContentItem':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type DATETIME
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -1128,30 +1057,12 @@ class DateTimeContentItem(ContentItem):
             Content Item
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'DateTimeContentItem':
-        """Construct object from an existing dataset.
-
-        Parameters
-        ----------
-        dataset: pydicom.dataset.Dataset
-            Dataset representing an SR Content Item with value type DATETIME
-
-        Returns
-        -------
-        highdicom.sr.DateTimeContentItem
-            Content Item
-
-        Note
-        ----
-        Does not create a copy, but modifies `dataset`.
-
-        """
-        _assert_value_type(dataset, ValueTypeValues.DATETIME)
-        item = super(DateTimeContentItem, cls)._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        _assert_value_type(dataset_copy, ValueTypeValues.DATETIME)
+        item = super(DateTimeContentItem, cls)._from_dataset_base(dataset_copy)
         return cast(DateTimeContentItem, item)
 
 
@@ -1187,13 +1098,21 @@ class UIDRefContentItem(ContentItem):
         return UID(self.UID)
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'UIDRefContentItem':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'UIDRefContentItem':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type UIDREF
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -1201,30 +1120,12 @@ class UIDRefContentItem(ContentItem):
             Content Item
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'UIDRefContentItem':
-        """Construct object from an existing dataset.
-
-        Parameters
-        ----------
-        dataset: pydicom.dataset.Dataset
-            Dataset representing an SR Content Item with value type UIDREF
-
-        Returns
-        -------
-        highdicom.sr.UIDRefContentItem
-            Content Item
-
-        Note
-        ----
-        Does not create a copy, but modifies `dataset`.
-
-        """
-        _assert_value_type(dataset, ValueTypeValues.UIDREF)
-        item = super(UIDRefContentItem, cls)._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        _assert_value_type(dataset_copy, ValueTypeValues.UIDREF)
+        item = super(UIDRefContentItem, cls)._from_dataset_base(dataset_copy)
         return cast(UIDRefContentItem, item)
 
 
@@ -1316,13 +1217,21 @@ class NumContentItem(ContentItem):
             return None
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'NumContentItem':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'NumContentItem':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type NUM
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -1330,42 +1239,24 @@ class NumContentItem(ContentItem):
             Content Item
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'NumContentItem':
-        """Construct object from an existing dataset.
-
-        Parameters
-        ----------
-        dataset: pydicom.dataset.Dataset
-            Dataset representing an SR Content Item with value type NUM
-
-        Returns
-        -------
-        highdicom.sr.NumContentItem
-            Content Item
-
-        Note
-        ----
-        Does not create a copy, but modifies `dataset`.
-
-        """
-        _assert_value_type(dataset, ValueTypeValues.NUM)
-        item = super(NumContentItem, cls)._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        _assert_value_type(dataset_copy, ValueTypeValues.NUM)
+        item = super(NumContentItem, cls)._from_dataset_base(dataset_copy)
         unit_item = (
             item
             .MeasuredValueSequence[0]
             .MeasurementUnitsCodeSequence[0]
         )
         item.MeasuredValueSequence[0].MeasurementUnitsCodeSequence = [
-            CodedConcept.from_dataset(unit_item)
+            CodedConcept.from_dataset(unit_item, copy=False)
         ]
         if hasattr(item, 'NumericValueQualifierCodeSequence'):
             qualifier_item = item.NumericValueQualifierCodeSequence[0]
             item.NumericValueQualifierCodeSequence = DataElementSequence([
-                CodedConcept.from_dataset(qualifier_item)
+                CodedConcept.from_dataset(qualifier_item, copy=False)
             ])
         return cast(NumContentItem, item)
 
@@ -1418,13 +1309,21 @@ class ContainerContentItem(ContentItem):
             return None
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'ContainerContentItem':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'ContainerContentItem':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type CONTAINER
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -1432,30 +1331,12 @@ class ContainerContentItem(ContentItem):
             Content Item
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'ContainerContentItem':
-        """Construct object from an existing dataset.
-
-        Parameters
-        ----------
-        dataset: pydicom.dataset.Dataset
-            Dataset representing an SR Content Item with value type CONTAINER
-
-        Returns
-        -------
-        highdicom.sr.ContainerContentItem
-            Content Item
-
-        Note
-        ----
-        Does not create a copy, but modifies `dataset`.
-
-        """
-        _assert_value_type(dataset, ValueTypeValues.CONTAINER)
-        item = super(ContainerContentItem, cls)._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        _assert_value_type(dataset_copy, ValueTypeValues.CONTAINER)
+        item = super(ContainerContentItem, cls)._from_dataset_base(dataset_copy)
         return cast(ContainerContentItem, item)
 
 
@@ -1513,13 +1394,21 @@ class CompositeContentItem(ContentItem):
         return UID(self.ReferencedSOPSequence[0].ReferencedSOPInstanceUID)
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'CompositeContentItem':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'CompositeContentItem':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type COMPOSITE
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -1527,30 +1416,12 @@ class CompositeContentItem(ContentItem):
             Content Item
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'CompositeContentItem':
-        """Construct object from an existing dataset.
-
-        Parameters
-        ----------
-        dataset: pydicom.dataset.Dataset
-            Dataset representing an SR Content Item with value type COMPOSITE
-
-        Returns
-        -------
-        highdicom.sr.CompositeContentItem
-            Content Item
-
-        Note
-        ----
-        Does not create a copy, but modifies `dataset`.
-
-        """
-        _assert_value_type(dataset, ValueTypeValues.COMPOSITE)
-        item = super(CompositeContentItem, cls)._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        _assert_value_type(dataset_copy, ValueTypeValues.COMPOSITE)
+        item = super(CompositeContentItem, cls)._from_dataset_base(dataset_copy)
         return cast(CompositeContentItem, item)
 
 
@@ -1660,13 +1531,21 @@ class ImageContentItem(ContentItem):
             return [int(val)]
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'ImageContentItem':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'ImageContentItem':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type IMAGE
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -1674,30 +1553,12 @@ class ImageContentItem(ContentItem):
             Content Item
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'ImageContentItem':
-        """Construct object from an existing dataset.
-
-        Parameters
-        ----------
-        dataset: pydicom.dataset.Dataset
-            Dataset representing an SR Content Item with value type IMAGE
-
-        Returns
-        -------
-        highdicom.sr.ImageContentItem
-            Content Item
-
-        Note
-        ----
-        Does not create a copy, but modifies `dataset`.
-
-        """
-        _assert_value_type(dataset, ValueTypeValues.IMAGE)
-        item = super(ImageContentItem, cls)._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        _assert_value_type(dataset_copy, ValueTypeValues.IMAGE)
+        item = super(ImageContentItem, cls)._from_dataset_base(dataset_copy)
         return cast(ImageContentItem, item)
 
 
@@ -1800,13 +1661,21 @@ class ScoordContentItem(ContentItem):
         return GraphicTypeValues(self.GraphicType)
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'ScoordContentItem':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'ScoordContentItem':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type SCOORD
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -1814,30 +1683,12 @@ class ScoordContentItem(ContentItem):
             Content Item
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'ScoordContentItem':
-        """Construct object from an existing dataset.
-
-        Parameters
-        ----------
-        dataset: pydicom.dataset.Dataset
-            Dataset representing an SR Content Item with value type SCOORD
-
-        Returns
-        -------
-        highdicom.sr.ScoordContentItem
-            Content Item
-
-        Note
-        ----
-        Does not create a copy, but modifies `dataset`.
-
-        """
-        _assert_value_type(dataset, ValueTypeValues.SCOORD)
-        item = super(ScoordContentItem, cls)._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        _assert_value_type(dataset_copy, ValueTypeValues.SCOORD)
+        item = super(ScoordContentItem, cls)._from_dataset_base(dataset_copy)
         return cast(ScoordContentItem, item)
 
 
@@ -1936,13 +1787,21 @@ class Scoord3DContentItem(ContentItem):
         return UID(self.ReferencedFrameOfReferenceUID)
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'Scoord3DContentItem':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'Scoord3DContentItem':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type SCOORD3D
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -1950,30 +1809,12 @@ class Scoord3DContentItem(ContentItem):
             Content Item
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'Scoord3DContentItem':
-        """Construct object from an existing dataset.
-
-        Parameters
-        ----------
-        dataset: pydicom.dataset.Dataset
-            Dataset representing an SR Content Item with value type SCOORD3D
-
-        Returns
-        -------
-        highdicom.sr.Scoord3DContentItem
-            Content Item
-
-        Note
-        ----
-        Does not create a copy, but modifies `dataset`.
-
-        """
-        _assert_value_type(dataset, ValueTypeValues.SCOORD3D)
-        item = super(Scoord3DContentItem, cls)._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        _assert_value_type(dataset_copy, ValueTypeValues.SCOORD3D)
+        item = super(Scoord3DContentItem, cls)._from_dataset_base(dataset_copy)
         return cast(Scoord3DContentItem, item)
 
 
@@ -2054,13 +1895,21 @@ class TcoordContentItem(ContentItem):
         return TemporalRangeTypeValues(self.TemporalRangeType)
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'TcoordContentItem':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'TcoordContentItem':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type TCOORD
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -2068,30 +1917,12 @@ class TcoordContentItem(ContentItem):
             Content Item
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'TcoordContentItem':
-        """Construct object from an existing dataset.
-
-        Parameters
-        ----------
-        dataset: pydicom.dataset.Dataset
-            Dataset representing an SR Content Item with value type TCOORD
-
-        Returns
-        -------
-        highdicom.sr.TcoordContentItem
-            Content Item
-
-        Note
-        ----
-        Does not create a copy, but modifies `dataset`.
-
-        """
-        _assert_value_type(dataset, ValueTypeValues.TCOORD)
-        item = super(TcoordContentItem, cls)._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        _assert_value_type(dataset_copy, ValueTypeValues.TCOORD)
+        item = super(TcoordContentItem, cls)._from_dataset_base(dataset_copy)
         return cast(TcoordContentItem, item)
 
 
@@ -2186,13 +2017,21 @@ class WaveformContentItem(ContentItem):
         ]
 
     @classmethod
-    def from_dataset(cls, dataset: Dataset) -> 'WaveformContentItem':
+    def from_dataset(
+        cls,
+        dataset: Dataset,
+        copy: bool = True,
+    ) -> 'WaveformContentItem':
         """Construct object from an existing dataset.
 
         Parameters
         ----------
         dataset: pydicom.dataset.Dataset
             Dataset representing an SR Content Item with value type WAVEFORM
+        copy: bool
+            If True, the underlying dataset is deep-copied such that the
+            original dataset remains intact. If False, this operation will
+            alter the original dataset in place.
 
         Returns
         -------
@@ -2200,28 +2039,10 @@ class WaveformContentItem(ContentItem):
             Content Item
 
         """
-        dataset_copy = deepcopy(dataset)
-        return cls._from_dataset(dataset_copy)
-
-    @classmethod
-    def _from_dataset(cls, dataset: Dataset) -> 'WaveformContentItem':
-        """Construct object from an existing dataset.
-
-        Parameters
-        ----------
-        dataset: pydicom.dataset.Dataset
-            Dataset representing an SR Content Item with value type WAVEFORM
-
-        Returns
-        -------
-        highdicom.sr.WaveformContentItem
-            Content Item
-
-        Note
-        ----
-        Does not create a copy, but modifies `dataset`.
-
-        """
-        _assert_value_type(dataset, ValueTypeValues.IMAGE)
-        item = super(WaveformContentItem, cls)._from_dataset_base(dataset)
+        if copy:
+            dataset_copy = deepcopy(dataset)
+        else:
+            dataset_copy = dataset
+        _assert_value_type(dataset_copy, ValueTypeValues.IMAGE)
+        item = super(WaveformContentItem, cls)._from_dataset_base(dataset_copy)
         return cast(WaveformContentItem, item)

--- a/tests/test_seg.py
+++ b/tests/test_seg.py
@@ -2565,6 +2565,13 @@ class TestSegmentationParsing(unittest.TestCase):
     def test_from_dataset(self):
         assert isinstance(self._sm_control_seg, Segmentation)
 
+    def test_from_dataset_copy_false(self):
+        seg_ds = dcmread(
+            'data/test_files/seg_image_sm_control.dcm'
+        )
+        seg = Segmentation.from_dataset(seg_ds, copy=False)
+        assert seg is seg_ds
+
     def test_segread(self):
         seg = segread('data/test_files/seg_image_ct_true_fractional.dcm')
         assert isinstance(seg, Segmentation)

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -577,6 +577,14 @@ class TestContentItem(unittest.TestCase):
         assert isinstance(item.name, CodedConcept)
         assert item.name == name
         assert item.TextValue == dataset.TextValue
+        assert item is not dataset
+
+        item = TextContentItem.from_dataset(dataset, copy=False)
+        assert isinstance(item, TextContentItem)
+        assert isinstance(item.name, CodedConcept)
+        assert item.name == name
+        assert item.TextValue == dataset.TextValue
+        assert item is dataset
 
     def test_text_item_from_dataset_with_missing_name(self):
         dataset = Dataset()

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -3996,6 +3996,15 @@ class TestComprehensive3DSR(unittest.TestCase):
         assert isinstance(report, Comprehensive3DSR)
         assert isinstance(report.content, ContentSequence)
         assert isinstance(report.content, MeasurementReport)
+        assert report is not self._sr_document
+
+    def test_from_dataset_no_copy(self):
+        tmp = deepcopy(self._sr_document)
+        report = Comprehensive3DSR.from_dataset(tmp, copy=False)
+        assert isinstance(report, Comprehensive3DSR)
+        assert isinstance(report.content, ContentSequence)
+        assert isinstance(report.content, MeasurementReport)
+        assert report is tmp
 
     def test_evidence_duplication(self):
         report = Comprehensive3DSR(


### PR DESCRIPTION
Tweaked all `from_dataset` methods to accept a new boolean `copy` parameter (default `True`) in order to skip the copy operation to improve performance. If `False`, the dataset parameter is altered in place. This is now used in the `segread` method, and dramatically improves the performance there.

@pieper this should cut around 25% off your large seg benchmark time based on my testing 